### PR TITLE
Fix webassembly problems

### DIFF
--- a/qt-qml-gui/SettingsMenu.qml
+++ b/qt-qml-gui/SettingsMenu.qml
@@ -126,25 +126,6 @@ Menu {
         }
     }
 
-    enter: Transition {
-        ParallelAnimation {
-            NumberAnimation {
-                property: "width"
-                from: 0
-                to: settingsMenu.implicitWidth
-                easing.type: Easing.InOutExpo
-                duration: 350
-            }
-            NumberAnimation {
-                property: "height"
-                from: 0
-                to: settingsMenu.implicitHeight
-                easing.type: Easing.InOutExpo
-                duration: 350
-            }
-        }
-    }
-
     QtObject {
         id: internal
         property bool menuIsFullyVisible: settingsMenu.width >= settingsMenu.implicitWidth

--- a/qt-qml-gui/chessengine.cpp
+++ b/qt-qml-gui/chessengine.cpp
@@ -190,3 +190,8 @@ void ChessEngine::updateConfig(ChessGame::Config config,
     // Possibly resume searching for the next move:
     init();
 }
+
+void ChessEngine::quit()
+{
+    QThread::currentThread()->quit();
+}

--- a/qt-qml-gui/chessengine.hpp
+++ b/qt-qml-gui/chessengine.hpp
@@ -28,6 +28,9 @@ public slots:
     // Startup the engine. If it's the engine's turn to move, make a move.
     void init();
 
+    // Exit the thread. Called upon application exit to cleanup.
+    void quit();
+
     // Receive events about the opponent move.
     void opponentMoved(wisdom::Move move, wisdom::Color who);
 

--- a/qt-qml-gui/gamemodel.cpp
+++ b/qt-qml-gui/gamemodel.cpp
@@ -121,7 +121,7 @@ void GameModel::setupNewEngineThread()
 
     // exit event loop from engine thread when we start exiting:
     connect(this, &GameModel::terminationStarted,
-            myChessEngineThread, &QThread::quit);
+            chessEngine, &ChessEngine::quit);
 
     // Update the engine's config when user changes it:
     connect(this, &GameModel::engineConfigChanged,
@@ -250,9 +250,15 @@ void GameModel::applicationExiting()
 
     // End the thread by changing the game id:
     myGameId = 0;
+    qDebug() << "Terminated start...";
     emit terminationStarted();
 
+    // For desktop, we need to wait here before exiting. But on web that will hang.
+#ifndef EMSCRIPTEN
     myChessEngineThread->wait();
+#endif
+
+    qDebug() << "Termination ended.";
 }
 
 void GameModel::updateEngineConfig()


### PR DESCRIPTION
- Remove animation from settings menu to avoid problem with flickering.
- Disable waiting for thread to exit on webassembly so that the
browser doesn't hang when closing.