### PR TITLE
Fix overlay generous castle penalty causing piece sacrifice

### DIFF
--- a/engine/src/evaluate.cpp
+++ b/engine/src/evaluate.cpp
@@ -6,7 +6,7 @@
 
 namespace wisdom
 {
-    static const int Castle_Penalty = 50;
+    static const int Castle_Penalty = 35;
 
     namespace
     {
@@ -58,7 +58,7 @@ namespace wisdom
         int score = 0;
         Color opponent = color_invert (who);
 
-        score += board.get_material().overall_score(who);
+        score += board.get_material ().overall_score (who);
         score += board.get_position ().overall_score (who);
 
         if (is_checkmated (board, who, generator))

--- a/engine/src/evaluate.cpp
+++ b/engine/src/evaluate.cpp
@@ -6,7 +6,7 @@
 
 namespace wisdom
 {
-    static const int Castle_Penalty = 35;
+    static constexpr int Castle_Penalty = 35;
 
     namespace
     {

--- a/engine/src/global.hpp
+++ b/engine/src/global.hpp
@@ -47,47 +47,47 @@ namespace wisdom
 
     namespace chrono = std::chrono;
 
-    constexpr int Num_Players = 2;
+    static constexpr int Num_Players = 2;
 
-    constexpr int Num_Rows = 8;
-    constexpr int Num_Columns = 8;
-    constexpr int Num_Squares = Num_Rows * Num_Columns;
+    static constexpr int Num_Rows = 8;
+    static constexpr int Num_Columns = 8;
+    static constexpr int Num_Squares = Num_Rows * Num_Columns;
 
-    constexpr int First_Row = 0;
-    constexpr int First_Column = 0;
+    static constexpr int First_Row = 0;
+    static constexpr int First_Column = 0;
 
-    constexpr int Last_Row = 7;
-    constexpr int Last_Column = 7;
+    static constexpr int Last_Row = 7;
+    static constexpr int Last_Column = 7;
 
-    constexpr int King_Column = 4;
-    constexpr int King_Rook_Column = 7;
-    constexpr int Queen_Rook_Column = 0;
+    static constexpr int King_Column = 4;
+    static constexpr int King_Rook_Column = 7;
+    static constexpr int Queen_Rook_Column = 0;
 
     // Where the color is vulnerable to en passant:
-    constexpr int White_En_Passant_Row = 5;
-    constexpr int Black_En_Passant_Row = 2;
+    static constexpr int White_En_Passant_Row = 5;
+    static constexpr int Black_En_Passant_Row = 2;
 
-    constexpr int Kingside_Castled_King_Column = 6;
-    constexpr int Queenside_Castled_King_Column = 2;
-    constexpr int Kingside_Castled_Rook_Column = 5;
-    constexpr int Queenside_Castled_Rook_Column = 3;
+    static constexpr int Kingside_Castled_King_Column = 6;
+    static constexpr int Queenside_Castled_King_Column = 2;
+    static constexpr int Kingside_Castled_Rook_Column = 5;
+    static constexpr int Queenside_Castled_Rook_Column = 3;
 
     // Infinity score.
-    constexpr int Infinity = 65536;
-    constexpr int Negative_Infinity = -1 * Infinity;
+    static constexpr int Infinity = 65536;
+    static constexpr int Negative_Infinity = -1 * Infinity;
 
     // Initial Alpha value.
-    constexpr int Initial_Alpha = Infinity * 3;
+    static constexpr int Initial_Alpha = Infinity * 3;
 
     // Default absolute max depth searched.
-    constexpr int Default_Max_Depth = 16;
+    static constexpr int Default_Max_Depth = 16;
 
     // Default max time spent searching.
-    constexpr int Default_Max_Search_Seconds = 5;
+    static constexpr int Default_Max_Search_Seconds = 5;
 
     // Minimum amount behind the computer must feel in order to
     // accept a draw offer.
-    constexpr int Min_Draw_Score = -500;
+    static constexpr int Min_Draw_Score = -500;
 
     // Errors in this application.
     class Error : public std::exception

--- a/engine/src/logger.cpp
+++ b/engine/src/logger.cpp
@@ -26,7 +26,7 @@ namespace wisdom
             : my_log_level { level }
         {}
 
-        ~StandardLogger() override = default;
+        ~StandardLogger () override = default;
 
         void debug (const string& output) const override
         {
@@ -50,15 +50,15 @@ namespace wisdom
         }
     };
 
-    auto make_null_logger () -> Logger&
+    auto make_null_logger () -> unique_ptr<Logger>
     {
-        static NullLogger null_logger {};
-        return null_logger;
+        return make_unique<NullLogger> ();
     }
 
-    auto make_standard_logger (Logger::LogLevel level) -> Logger&
+    auto make_standard_logger (Logger::LogLevel level) -> unique_ptr<Logger>
     {
-        static StandardLogger standard_logger { level };
-        return standard_logger;
+        return make_unique<StandardLogger> (level);
     }
 }
+
+

--- a/engine/src/logger.hpp
+++ b/engine/src/logger.hpp
@@ -20,8 +20,9 @@ namespace wisdom
         virtual void info (const string& output) const = 0;
     };
 
-    auto make_null_logger () -> Logger&;
-    auto make_standard_logger (Logger::LogLevel level = Logger::LogLevel_Debug) -> Logger&;
+    auto make_null_logger () -> unique_ptr<Logger>;
+
+    auto make_standard_logger (Logger::LogLevel level = Logger::LogLevel_Debug) -> unique_ptr<Logger>;
 }
 
 #endif // WISDOM_LOGGER_HPP

--- a/engine/src/play.cpp
+++ b/engine/src/play.cpp
@@ -112,7 +112,7 @@ namespace wisdom
         }
     }
 
-    static InputState read_move (Game& game, Logger& logger, MoveGenerator& move_generator)
+    static InputState read_move (Game& game, MoveGenerator& move_generator)
     {
         InputState result;
         string input;
@@ -347,7 +347,7 @@ namespace wisdom
     {
         Game game;
         InputState initial_input_state;
-        Logger& output = make_standard_logger ();
+        auto output = make_standard_logger ();
         bool paused = false;
         MoveGenerator move_generator;
 
@@ -363,7 +363,7 @@ namespace wisdom
 
             if (!paused && game.get_current_player () == Player::ChessEngine)
             {
-                auto optional_move = game.find_best_move (output);
+                auto optional_move = game.find_best_move (*output);
                 if (!optional_move.has_value ())
                 {
                     std::cout << "\nCouldn't find move!\n";
@@ -376,7 +376,7 @@ namespace wisdom
             }
             else
             {
-                input_state = read_move (game, output, move_generator);
+                input_state = read_move (game, move_generator);
 
                 if (input_state.command == PlayCommand::StopGame)
                     break;

--- a/engine/src/position.cpp
+++ b/engine/src/position.cpp
@@ -129,7 +129,7 @@ namespace wisdom
         assert (this->my_score[inverted] < 3000 && this->my_score[inverted] > -3000);
         int result = this->my_score[index] - this->my_score[inverted];
         assert (result < 3000);
-        return result * 10;
+        return result * 9;
     }
 
     void Position::add (Color who, Coord coord, ColoredPiece piece)

--- a/engine/test/search_test.cpp
+++ b/engine/test/search_test.cpp
@@ -269,3 +269,17 @@ TEST_CASE ("Can avoid stalemate")
     CHECK( !is_stalemate );
 }
 
+TEST_CASE( "Doesn't sacrifice piece to undermine opponent's castle position" )
+{
+    FenParser fen { "r1bqkb1r/2pppppp/p4n2/np6/8/1B2PN2/PPPP1PPP/RNBQK2R w KQkq - 0 1 " };
+
+    auto game = fen.build ();
+
+    SearchHelper helper;
+    IterativeSearch search = helper.build (game.get_board (), 5, 5);
+    SearchResult result = search.iteratively_deepen (Color::White);
+
+    // Check the white bishop is not sacrificed:
+    CHECK( *result.move != move_parse ("b3xf7"));
+}
+

--- a/engine/test/search_test.cpp
+++ b/engine/test/search_test.cpp
@@ -20,11 +20,16 @@ namespace wisdom::test
     struct SearchHelper
     {
         History history {};
+        static inline std::unique_ptr<wisdom::Logger> null_logger;
 
         IterativeSearch build (Board& board, int depth, int time = 30)
         {
             MoveTimer timer { time };
-            return { board, history, make_null_logger (), timer, depth };
+            if (!null_logger) {
+                null_logger = make_null_logger ();
+            }
+
+            return { board, history, *null_logger, timer, depth };
         }
     };
 }

--- a/qt-qml-gui/chessengine.cpp
+++ b/qt-qml-gui/chessengine.cpp
@@ -13,6 +13,11 @@ using gsl::not_null;
 using wisdom::GameStatus;
 using wisdom::ProposedDrawType;
 
+void ChessEngine::ChessEngineLogger::info(const std::string& line) const
+{
+    qDebug() << line.c_str();
+}
+
 ChessEngine::ChessEngine(shared_ptr<ChessGame> game, int gameId, QObject *parent)
     : QObject { parent }
     , myGame { std::move(game) }
@@ -78,7 +83,7 @@ auto ChessEngine::gameStatusTransition () -> wisdom::GameStatus
 void ChessEngine::findMove()
 {
     auto gameState = myGame->state();
-    Logger& output = make_standard_logger(Log_Level);
+    auto output = ChessEngineLogger {};
 
     if (myIsGameOver) {
         return;

--- a/qt-qml-gui/chessengine.hpp
+++ b/qt-qml-gui/chessengine.hpp
@@ -33,6 +33,14 @@ public:
 #endif
         ;
 
+    struct ChessEngineLogger : wisdom::Logger
+    {
+        void debug (const std::string& string) const override
+        {}
+
+        void info (const std::string& string) const override;
+    };
+
 public slots:
     // Startup the engine. If it's the engine's turn to move, make a move.
     void init();


### PR DESCRIPTION
- Add a test where the engine was sacrificing a bishop to undermine its opponent's castle position
- Reduce the position multiplier to fix anoter test that fails when the castle penalty is reduced. Apparently the high castle
penalty was compensating for another problem there. The test in question was ""Promoted pawn is promoted to highest value piece even when capturing", and was moving another piece instead of capturing a bishop to promote to a (to-be-sacrificed) queen.