### PR TITLE
Fix sacrifice problem with material score

### DIFF
--- a/engine/src/board_code.cpp
+++ b/engine/src/board_code.cpp
@@ -14,8 +14,6 @@ namespace wisdom
         Color current_turn,
         PlayerCastleState castling_state
     ) {
-        int8_t row, col;
-
         for (auto coord : board.all_coords ())
         {
             ColoredPiece piece = board.piece_at (coord);

--- a/engine/src/evaluate.cpp
+++ b/engine/src/evaluate.cpp
@@ -6,7 +6,7 @@
 
 namespace wisdom
 {
-    static constexpr int Castle_Penalty = 35;
+    static constexpr int Castle_Penalty = 50;
 
     namespace
     {

--- a/engine/src/evaluate.hpp
+++ b/engine/src/evaluate.hpp
@@ -25,13 +25,13 @@ namespace wisdom
     // further away.
     inline auto checkmate_score_in_moves (int moves) -> int
     {
-        return Infinity + Infinity / (1 + moves);
+        return Max_Non_Checkmate_Score + Max_Non_Checkmate_Score / (1 + moves);
     }
 
     // Whether the score indicates a checkmate of the opponent has been found.
     inline auto is_checkmating_opponent_score (int score) -> bool
     {
-        return score > Infinity;
+        return score > Max_Non_Checkmate_Score && score < Initial_Alpha;
     }
 }
 

--- a/engine/src/global.hpp
+++ b/engine/src/global.hpp
@@ -47,6 +47,17 @@ namespace wisdom
 
     namespace chrono = std::chrono;
 
+    enum MaterialWeight
+    {
+        WeightNone = 0,
+        WeightKing = 1500,
+        WeightQueen = 1000,
+        WeightRook = 500,
+        WeightBishop = 320,
+        WeightKnight = 305,
+        WeightPawn = 100,
+    };
+
     static constexpr int Num_Players = 2;
 
     static constexpr int Num_Rows = 8;
@@ -72,12 +83,21 @@ namespace wisdom
     static constexpr int Kingside_Castled_Rook_Column = 5;
     static constexpr int Queenside_Castled_Rook_Column = 3;
 
-    // Infinity score.
-    static constexpr int Infinity = 65536;
-    static constexpr int Negative_Infinity = -1 * Infinity;
+    // Scale factor for the material and position scale. Used for balancing material
+    // and position scores together.
+    static constexpr int Material_Score_Scale = 2;
+    static constexpr int Position_Score_Scale = 10;
 
-    // Initial Alpha value.
-    static constexpr int Initial_Alpha = Infinity * 3;
+    // Initial Alpha value for alpha-beta search.
+    static constexpr int Initial_Alpha = INT_MAX / 3;
+
+    // Infinite score - regular scores can never be this high.
+    // Checkmates are scored above this, depending on how far
+    // away from the current position they are.
+    static constexpr int Max_Non_Checkmate_Score
+        = Num_Squares * WeightQueen *
+        std::max (Material_Score_Scale, Position_Score_Scale);
+    static_assert (Max_Non_Checkmate_Score > 100'000 && Max_Non_Checkmate_Score < Initial_Alpha);
 
     // Default absolute max depth searched.
     static constexpr int Default_Max_Depth = 16;

--- a/engine/src/material.hpp
+++ b/engine/src/material.hpp
@@ -21,17 +21,6 @@ namespace wisdom
 
         explicit Material (const Board& board);
 
-        enum MaterialWeight
-        {
-            WeightNone = 0,
-            WeightKing = 1500,
-            WeightQueen = 1000,
-            WeightRook = 500,
-            WeightBishop = 320,
-            WeightKnight = 305,
-            WeightPawn = 100,
-        };
-
         [[nodiscard]] static int weight (Piece piece) noexcept
         {
             switch (piece)
@@ -45,6 +34,11 @@ namespace wisdom
                 case Piece::Pawn: return WeightPawn;
             }
             std::terminate ();
+        }
+
+        [[nodiscard]] static auto score_with_scale (int score) -> int
+        {
+            return score * Material_Score_Scale;
         }
 
         void add (ColoredPiece piece)
@@ -72,14 +66,14 @@ namespace wisdom
         [[nodiscard]] auto individual_score (Color who) const -> int
         {
             ColorIndex my_index = color_index (who);
-            return my_score[my_index];
+            return score_with_scale (my_score[my_index]);
         }
 
         [[nodiscard]] auto overall_score (Color who) const -> int
         {
             ColorIndex my_index = color_index (who);
             ColorIndex opponent_index = color_index (color_invert (who));
-            return my_score[my_index] - my_score[opponent_index];
+            return score_with_scale (my_score[my_index] - my_score[opponent_index]);
         }
 
         [[nodiscard]] auto piece_count (Color who, Piece type) const -> int
@@ -101,8 +95,8 @@ namespace wisdom
                 return true;
             }
 
-            if (individual_score (Color::White) > WeightKing + 2 * WeightBishop ||
-                individual_score (Color::Black) > WeightKing + 2 * WeightBishop)
+            if (individual_score (Color::White) > score_with_scale (WeightKing + 2 * WeightBishop) ||
+                individual_score (Color::Black) > score_with_scale (WeightKing + 2 * WeightBishop))
             {
                 return true;
             }

--- a/engine/src/position.cpp
+++ b/engine/src/position.cpp
@@ -129,7 +129,7 @@ namespace wisdom
         assert (this->my_score[inverted] < 3000 && this->my_score[inverted] > -3000);
         int result = this->my_score[index] - this->my_score[inverted];
         assert (result < 3000);
-        return result * 9;
+        return result * Position_Score_Scale;
     }
 
     void Position::add (Color who, Coord coord, ColoredPiece piece)

--- a/engine/test/search_test.cpp
+++ b/engine/test/search_test.cpp
@@ -64,7 +64,7 @@ TEST_CASE ("Can find mate in 3")
 
     SearchResult result = search.iteratively_deepen (Color::White);
 
-    CHECK (result.score > Infinity);
+    CHECK (result.score > Max_Non_Checkmate_Score);
     CHECK (result.move.has_value ());
 }
 
@@ -87,7 +87,7 @@ TEST_CASE ("Can find mate in 2 1/2")
     SearchResult result = search.iteratively_deepen (Color::Black);
 
     REQUIRE( result.move.has_value () );
-    REQUIRE( result.score > Infinity );
+    REQUIRE( result.score > Max_Non_Checkmate_Score);
 }
 
 TEST_CASE ("scenario with heap overflow 1")
@@ -251,8 +251,6 @@ TEST_CASE( "Checkmate is preferred to stalemate" )
 
     REQUIRE( result.move.has_value ());
 
-    std::cout << to_string (*result.move) << "\n";
-
     game.move (*result.move);
     auto is_stalemate = is_stalemated (game.get_board (), Color::White, *game.get_move_generator ());
     CHECK( !is_stalemate );
@@ -274,17 +272,32 @@ TEST_CASE ("Can avoid stalemate")
     CHECK( !is_stalemate );
 }
 
-TEST_CASE( "Doesn't sacrifice piece to undermine opponent's castle position" )
+TEST_CASE ("Doesn't sacrifice piece to undermine opponent's castle position")
 {
     FenParser fen { "r1bqkb1r/2pppppp/p4n2/np6/8/1B2PN2/PPPP1PPP/RNBQK2R w KQkq - 0 1 " };
 
-    auto game = fen.build ();
+    SUBCASE( "Depth 5" )
+    {
+        auto game = fen.build ();
 
-    SearchHelper helper;
-    IterativeSearch search = helper.build (game.get_board (), 5, 5);
-    SearchResult result = search.iteratively_deepen (Color::White);
+        SearchHelper helper;
+        IterativeSearch search = helper.build (game.get_board (), 5, 5);
+        SearchResult result = search.iteratively_deepen (Color::White);
 
-    // Check the white bishop is not sacrificed:
-    CHECK( *result.move != move_parse ("b3xf7"));
+        // Check the white bishop is not sacrificed:
+        CHECK (*result.move != move_parse ("b3xf7"));
+    }
+
+    SUBCASE( "Depth 7" )
+    {
+        auto game = fen.build ();
+
+        SearchHelper helper;
+        IterativeSearch search = helper.build (game.get_board (), 7, 10);
+        SearchResult result = search.iteratively_deepen (Color::White);
+
+        // Check the white bishop is not sacrificed:
+        CHECK (*result.move != move_parse ("b3xf7"));
+    }
 }
 


### PR DESCRIPTION
- Revert castle penalty score change
- Multiply the material score by a scale factor instead
- Rework the `Initial_Alpha` and `Infinity` by calculating them
- Rename `Infinity` to `Max_Non_Checkmate_Score`