### PR TITLE
Move list delete rvalue ref funcs

### DIFF
--- a/engine/src/global.hpp
+++ b/engine/src/global.hpp
@@ -45,6 +45,9 @@ namespace wisdom
     using std::array;
     using std::pair;
 
+    template <typename T>
+    using observer_ptr = T*;
+
     namespace chrono = std::chrono;
 
     enum MaterialWeight

--- a/engine/src/global.hpp
+++ b/engine/src/global.hpp
@@ -2,6 +2,7 @@
 #define WISDOM_CHESS_GLOBAL_HPP
 
 #include <cstdint>
+#include <climits>
 #include <exception>
 #include <string>
 #include <utility>

--- a/engine/src/gsl.hpp
+++ b/engine/src/gsl.hpp
@@ -9,6 +9,9 @@ namespace gsl
     using zstring = char*;
     using czstring = const char*;
 
+    template <typename T>
+    using owner = T;
+
     template <typename T, typename U>
     constexpr auto narrow_cast(U anything) -> T
     {

--- a/engine/src/move_list.cpp
+++ b/engine/src/move_list.cpp
@@ -26,7 +26,10 @@ namespace wisdom
         return result;
     }
 
-    auto to_string (const MoveList& list) -> string { return list.to_string (); }
+    auto to_string (const MoveList& list) -> string
+    {
+        return list.to_string ();
+    }
 
     auto operator<< (std::ostream& os, const MoveList& list) -> std::ostream&
     {
@@ -37,8 +40,6 @@ namespace wisdom
     //
     // New Move list things
     //
-
-    std::size_t move_list_capacity (move_list& ptr) noexcept { return ptr.capacity; }
 
     void move_list_append (move_list& list, std::size_t position, Move move) noexcept
     {

--- a/engine/src/move_list.cpp
+++ b/engine/src/move_list.cpp
@@ -36,42 +36,4 @@ namespace wisdom
         os << to_string (list);
         return os;
     }
-
-    //
-    // New Move list things
-    //
-
-    void move_list_append (move_list& list, std::size_t position, Move move) noexcept
-    {
-        assert (position <= list.capacity);
-
-        if (position == list.capacity)
-        {
-            list.capacity += MoveListAllocator::Size_Increment;
-
-            std::size_t new_capacity_in_bytes = list.capacity * sizeof (Move);
-            list.move_array = (Move*)realloc (list.move_array, new_capacity_in_bytes);
-        }
-
-        assert (list.move_array != nullptr);
-        list.move_array[position] = move;
-    }
-
-    auto MoveListAllocator::alloc_move_list() noexcept -> unique_ptr<move_list>
-    {
-        if (!my_move_list_ptrs.empty ())
-        {
-            auto move_list_end = std::move (my_move_list_ptrs.back ());
-            my_move_list_ptrs.pop_back ();
-            return move_list_end;
-        }
-
-        return default_alloc_move_list ();
-    }
-
-    void MoveListAllocator::dealloc_move_list (unique_ptr<move_list> move_list) noexcept
-    {
-        if (move_list != nullptr)
-            my_move_list_ptrs.emplace_back (std::move (move_list));
-    }
 }

--- a/engine/src/move_list.hpp
+++ b/engine/src/move_list.hpp
@@ -36,8 +36,6 @@ namespace wisdom
         void dealloc_move_list (unique_ptr<move_list> move_list) noexcept;
     };
 
-    std::size_t move_list_capacity (move_list& ptr) noexcept;
-
     void move_list_append (move_list& list, std::size_t position, Move move) noexcept;
 
     inline auto default_alloc_move_list () -> unique_ptr<move_list>
@@ -156,7 +154,7 @@ namespace wisdom
 
         [[nodiscard]] size_t capacity () const noexcept
         {
-            return move_list_capacity (*my_moves_list);
+            return my_moves_list->capacity;
         }
 
         [[nodiscard]] auto to_string () const -> string;

--- a/engine/src/move_list.hpp
+++ b/engine/src/move_list.hpp
@@ -12,15 +12,6 @@ namespace wisdom
     {
         Move* move_array;
         std::size_t capacity;
-
-        ~move_list()
-        {
-            if (move_array != nullptr)
-            {
-                std::cout << "Leaked!";
-                std::terminate ();
-            }
-        }
     };
 
     class MoveListAllocator

--- a/engine/src/move_list.hpp
+++ b/engine/src/move_list.hpp
@@ -108,35 +108,41 @@ namespace wisdom
             my_size--;
         }
 
-        [[nodiscard]] auto begin () const noexcept -> const Move*
+        [[nodiscard]] auto begin () const& noexcept -> const Move*
         {
             return my_moves_list->move_array;
         }
+        void begin () const&& = delete;
 
-        [[nodiscard]] auto end () const noexcept -> const Move*
+        [[nodiscard]] auto end () const& noexcept -> const Move*
         {
             return my_moves_list->move_array + my_size;
         }
+        void end () const&& = delete;
 
-        [[nodiscard]] auto cbegin () const noexcept -> const Move*
+        [[nodiscard]] auto cbegin () const& noexcept -> const Move*
         {
             return my_moves_list->move_array;
         }
+        void cbegin () const&& = delete;
 
-        [[nodiscard]] auto cend () const noexcept -> const Move*
+        [[nodiscard]] auto cend () const& noexcept -> const Move*
         {
             return my_moves_list->move_array + my_size;
         }
+        void cend () const&& = delete;
 
-        [[nodiscard]] auto begin () noexcept -> Move*
+        [[nodiscard]] auto begin () & noexcept -> Move*
         {
             return my_moves_list->move_array;
         }
+        void begin () && = delete;
 
-        [[nodiscard]] auto end () noexcept -> Move*
+        [[nodiscard]] auto end () & noexcept -> Move*
         {
             return my_moves_list->move_array + my_size;
         }
+        void end () && = delete;
 
         [[nodiscard]] bool empty () const noexcept
         {

--- a/engine/src/move_list.hpp
+++ b/engine/src/move_list.hpp
@@ -174,20 +174,23 @@ namespace wisdom
             return !(*this == other);
         }
 
-        [[nodiscard]] auto data () const noexcept -> Move*
+        [[nodiscard]] auto data () const& noexcept -> Move*
         {
             return my_moves_list->move_array;
         }
+        void data () const&& = delete;
 
-        [[nodiscard]] auto ptr () const noexcept -> move_list*
+        [[nodiscard]] auto ptr () const& noexcept -> move_list*
         {
             return my_moves_list.get ();
         }
+        void ptr () const&& = delete;
 
-        [[nodiscard]] auto allocator () const noexcept -> MoveListAllocator*
+        [[nodiscard]] auto allocator () const& noexcept -> MoveListAllocator*
         {
             return my_allocator;
         }
+        void allocator () const&& = delete;
     };
 
     auto to_string (const MoveList& list) -> string;

--- a/engine/src/move_list.hpp
+++ b/engine/src/move_list.hpp
@@ -99,15 +99,10 @@ namespace wisdom
         MoveList& operator= (const MoveList& other) = delete;
 
         MoveList (MoveList&& other) noexcept
-            : my_moves_list { nullptr }
-            , my_size { 0 }
-            , my_allocator { nullptr }
+            : my_moves_list { std::move (other.my_moves_list) }
+            , my_size { other.my_size }
+            , my_allocator { other.my_allocator }
         {
-            my_moves_list = std::move (other.my_moves_list);
-            my_size = other.my_size;
-            my_allocator = other.my_allocator;
-            other.my_size = 0;
-            other.my_allocator = nullptr;
         }
 
         MoveList& operator= (MoveList&& other) noexcept

--- a/engine/src/search.cpp
+++ b/engine/src/search.cpp
@@ -15,9 +15,9 @@ namespace wisdom
     class IterativeSearchImpl
     {
     private:
-        not_null<Board*> my_board;
-        not_null<History*> my_history;
-        not_null<const Logger*> my_output;
+        not_null<observer_ptr<Board>> my_board;
+        not_null<observer_ptr<History>> my_history;
+        not_null<observer_ptr<const Logger>> my_output;
         MoveGenerator my_generator {};
         MoveTimer my_timer;
         int my_total_depth;

--- a/engine/test/en_passant_test.cpp
+++ b/engine/test/en_passant_test.cpp
@@ -3,6 +3,7 @@
 
 #include "board.hpp"
 #include "generate.hpp"
+#include "coord.hpp"
 
 using namespace wisdom;
 
@@ -14,6 +15,9 @@ TEST_CASE( "en passant" )
 
         REQUIRE( !board.is_en_passant_vulnerable ( Color::White) );
         REQUIRE( !board.is_en_passant_vulnerable ( Color::Black) );
+
+        REQUIRE( board.get_en_passant_target (Color::White) == No_En_Passant_Coord );
+        REQUIRE( board.get_en_passant_target (Color::Black) == No_En_Passant_Coord );
 
         BoardBuilder builder;
         const auto& back_rank = BoardBuilder::Default_Piece_Row;

--- a/engine/test/en_passant_test.cpp
+++ b/engine/test/en_passant_test.cpp
@@ -55,16 +55,11 @@ TEST_CASE( "en passant" )
         REQUIRE( !is_en_passant_vulnerable (first_undo_state, Color::White) );
 
         MoveList move_list = move_generator.generate_all_potential_moves (board, Color::White);
-        std::optional<Move> optional_en_passant_move = nullopt;
+        auto maybe_en_passant_move = std::find_if (
+                move_list.begin (), move_list.end (), is_special_en_passant_move);
 
-        for (auto move : move_list)
-        {
-            if (is_special_en_passant_move (move))
-                optional_en_passant_move = move;
-        }
-
-        REQUIRE( optional_en_passant_move.has_value () );
-        auto en_passant_move = *optional_en_passant_move;
+        REQUIRE( maybe_en_passant_move != move_list.end () );
+        auto en_passant_move = *maybe_en_passant_move;
 
         // Check move types:
         REQUIRE( is_special_en_passant_move (en_passant_move) );
@@ -124,16 +119,11 @@ TEST_CASE( "en passant" )
         REQUIRE( !is_en_passant_vulnerable (first_undo_state, Color::White) );
 
         MoveList move_list = move_generator.generate_all_potential_moves (board, Color::White);
-        std::optional<Move> optional_en_passant_move = std::nullopt;
+        auto maybe_en_passant_move = std::find_if (
+                move_list.begin(), move_list.end (), is_special_en_passant_move);
 
-        for (auto move : move_list)
-        {
-            if (is_special_en_passant_move (move))
-                optional_en_passant_move = move;
-        }
-
-        REQUIRE( optional_en_passant_move.has_value () );
-        auto en_passant_move = *optional_en_passant_move;
+        REQUIRE( maybe_en_passant_move != move_list.end () );
+        auto en_passant_move = *maybe_en_passant_move;
 
         // Check move types:
         REQUIRE( is_special_en_passant_move (en_passant_move) );

--- a/engine/test/move_list_test.cpp
+++ b/engine/test/move_list_test.cpp
@@ -67,7 +67,8 @@ TEST_CASE( "Appending a move" )
 
 TEST_CASE( "Moving uncached list" )
 {
-#if 0
+    MoveListAllocator allocator;
+
     SUBCASE( "moving uncached into cached" )
     {
         MoveList uncached_list = MoveList::uncached ();
@@ -75,7 +76,6 @@ TEST_CASE( "Moving uncached list" )
         uncached_list.push_back (move_parse ("e4 d4"));
         uncached_list.push_back (move_parse ("d2 d1"));
 
-        MoveListAllocator allocator;
         MoveList cached { &allocator };
 
         REQUIRE( cached.allocator () != nullptr );
@@ -90,7 +90,6 @@ TEST_CASE( "Moving uncached list" )
         REQUIRE( *ptr++ == move_parse ("e4 d4", Color::Black) );
         REQUIRE( *ptr == move_parse ("d2 d1", Color::White) );
     }
-#endif
 
     SUBCASE( "moving cached into uncached" )
     {
@@ -99,7 +98,6 @@ TEST_CASE( "Moving uncached list" )
         uncached_list.push_back (move_parse ("e4 d4"));
         uncached_list.push_back (move_parse ("d2 d1"));
 
-        MoveListAllocator allocator;
         MoveList cached { &allocator };
 
         cached.push_back (move_parse ("e3 d3"));

--- a/engine/test/move_list_test.cpp
+++ b/engine/test/move_list_test.cpp
@@ -116,3 +116,27 @@ TEST_CASE( "Moving uncached list" )
         REQUIRE( *ptr == move_parse ("d3 d1", Color::White) );
     }
 }
+
+TEST_CASE( "Swapping lists" )
+{
+    MoveListAllocator allocator;
+
+    SUBCASE( "Swapping two simple lists" )
+    {
+        MoveList first = { Color::White, { "e2 d4", "a8 a1"} };
+        MoveList second = { Color::Black, { "d7 d5", "f1 c4" } };
+
+        std::swap (first, second);
+
+        auto first_string = to_string (first);
+        auto second_string = to_string (second);
+        std::cout << "first_string: " << first_string << "\n";
+        auto second_expected = string { "{ e2 d4, a8 a1 }" };
+        auto first_expected = string { "{ d7 d5", "f1 c4 }" };
+        bool first_equals =  first_expected == first_string;
+        bool second_equals = second_expected == second_string;
+
+        REQUIRE( first_equals );
+        REQUIRE( second_equals );
+    }
+}

--- a/engine/test/move_list_test.cpp
+++ b/engine/test/move_list_test.cpp
@@ -30,6 +30,13 @@ MoveList copy_moves_and_ptr (const Move **ptr, MoveGenerator& generator)
     return moves;
 }
 
+TEST_CASE( "Converting moves to a string" )
+{
+    MoveList list = { Color::White, { "e2 d4", "a8 a1"} };
+    std::string as_string = to_string (list);
+    REQUIRE( "{ [e2 d4] [a8 a1] }" == as_string );
+}
+
 TEST_CASE( "Returning move list moves ptr" )
 {
     const Move* ptr;
@@ -130,13 +137,26 @@ TEST_CASE( "Swapping lists" )
 
         auto first_string = to_string (first);
         auto second_string = to_string (second);
-        std::cout << "first_string: " << first_string << "\n";
-        auto second_expected = string { "{ e2 d4, a8 a1 }" };
-        auto first_expected = string { "{ d7 d5", "f1 c4 }" };
-        bool first_equals =  first_expected == first_string;
-        bool second_equals = second_expected == second_string;
 
-        REQUIRE( first_equals );
-        REQUIRE( second_equals );
+        CHECK( "{ [d7 d5] [f1 c4] }" == first_string );
+        CHECK( "{ [e2 d4] [a8 a1] }" == second_string );
+    }
+
+    SUBCASE( "Swapping two move lists with different allocators" )
+    {
+        MoveListAllocator allocator;
+        MoveList first { &allocator };
+        MoveList second = { Color::Black, { "d7 d5", "f1 c4" } };
+
+        first.push_back (move_parse ("e2 d4", Color::White));
+        first.push_back (move_parse ("a8 a1", Color::Black));
+
+        std::swap (first, second);
+
+        auto first_string = to_string (first);
+        auto second_string = to_string (second);
+
+        CHECK( "{ [d7 d5] [f1 c4] }" == first_string );
+        CHECK( "{ [e2 d4] [a8 a1] }" == second_string );
     }
 }


### PR DESCRIPTION
- Explicitly some rvalue getters of pointers to avoid dangling pointer problems
- Add `observer_ptr` template for documentation
- Implement move constructor and assignment operator for move list to avoid a memory leak of the old value on assignment
- Include `<climits>` to fix building on Linux