### PR TITLE
Upgrade to Qt 6.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,14 @@ project(WisdomChess CXX)
 
 option(WISDOM_CHESS_ASAN "Enable memory debugging of chess engine")
 option(WISDOM_CHESS_FAST_TESTS "Enable building of fast tests" On)
-option(WISDOM_CHESS_SLOW_TESTS "Enable building of fast tests")
+option(WISDOM_CHESS_SLOW_TESTS "Enable building of slow tests")
 
 if (QTDIR)
     list(APPEND CMAKE_PREFIX_PATH ${QTDIR})
     message("-- wisdom-chess: QTDIR added to CMAKE_PREFIX_PATH")
 endif()
 
-find_package(Qt6 6.2 QUIET COMPONENTS Quick)
+find_package(Qt6 6.4 QUIET COMPONENTS Quick)
 
 if (WISDOM_CHESS_ASAN)
     message("-- wisdom-chess: Enabling address sanitizer")

--- a/qt-qml-gui/AboutDialog.qml
+++ b/qt-qml-gui/AboutDialog.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick 
+import QtQuick.Controls 
 import "Helper.js" as Helper
 
 Dialog {

--- a/qt-qml-gui/Board.qml
+++ b/qt-qml-gui/Board.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Layouts
 import wisdom.chess 1.0
 
 Item {

--- a/qt-qml-gui/BoardDimensions.qml
+++ b/qt-qml-gui/BoardDimensions.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick
 
 QtObject {
     property int squareSize: calculateMaxSquareSize()

--- a/qt-qml-gui/ChessSquare.qml
+++ b/qt-qml-gui/ChessSquare.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick
 
 Item {
     property color bgColor: "white"

--- a/qt-qml-gui/DesktopRoot.qml
+++ b/qt-qml-gui/DesktopRoot.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick 
+import QtQuick.Controls 
+import QtQuick.Layouts 
 
 Item {
     width: parent.width

--- a/qt-qml-gui/Dialogs.qml
+++ b/qt-qml-gui/Dialogs.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick
 
 import "Helper.js" as Helper
 

--- a/qt-qml-gui/DrawProposalDialog.qml
+++ b/qt-qml-gui/DrawProposalDialog.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
+import QtQuick 
 import wisdom.chess 1.0
-import QtQuick.Controls 2.15
+import QtQuick.Controls 
 
 Dialog {
     property alias text: firstLine.text

--- a/qt-qml-gui/ImageToolButton.qml
+++ b/qt-qml-gui/ImageToolButton.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.0
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls 
 
 ToolButton {
     property alias imageSource: toolImage.source

--- a/qt-qml-gui/MobileRoot.qml
+++ b/qt-qml-gui/MobileRoot.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick 
+import QtQuick.Controls 
+import QtQuick.Layouts 
 
 Item {
     width: parent.width

--- a/qt-qml-gui/NewGameDialog.qml
+++ b/qt-qml-gui/NewGameDialog.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick 
+import QtQuick.Controls 
 import "Helper.js" as Helper
 
 Dialog {

--- a/qt-qml-gui/Piece.qml
+++ b/qt-qml-gui/Piece.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.15
+import QtQuick
 
 Image {
     id: myPieceImage

--- a/qt-qml-gui/PromoteDropdown.qml
+++ b/qt-qml-gui/PromoteDropdown.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.15
+import QtQuick
 import wisdom.chess 1.0
 
 FocusScope {

--- a/qt-qml-gui/PromotedPieceModel.qml
+++ b/qt-qml-gui/PromotedPieceModel.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.15
+import QtQuick
 
 ListModel {
     ListElement {

--- a/qt-qml-gui/SettingsMenu.qml
+++ b/qt-qml-gui/SettingsMenu.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick 
+import QtQuick.Controls 
+import QtQuick.Layouts 
 
 import "Helper.js" as Helper
 

--- a/qt-qml-gui/StatusBar.qml
+++ b/qt-qml-gui/StatusBar.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Layouts 
 import wisdom.chess 1.0
 
 ColumnLayout {

--- a/qt-qml-gui/desktop_main.qml
+++ b/qt-qml-gui/desktop_main.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.15
+import QtQuick 
 import wisdom.chess 1.0
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick.Controls 
+import QtQuick.Layouts 
 
 import "Helper.js" as Helper
 

--- a/qt-qml-gui/mobile_main.qml
+++ b/qt-qml-gui/mobile_main.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.15
+import QtQuick 
 import wisdom.chess 1.0
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick.Controls 
+import QtQuick.Layouts 
 
 ApplicationWindow {
     id: topWindow

--- a/qt-qml-gui/wasm_main.qml
+++ b/qt-qml-gui/wasm_main.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.15
+import QtQuick 
 import wisdom.chess 1.0
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick.Controls 
+import QtQuick.Layouts 
 
 import "Helper.js" as Helper
 


### PR DESCRIPTION
Qt 6.4 Web Assembly version doesn't seem to have the flickering problem (Issue https://github.com/dmeybohm/wisdom-chess/issues/9)

Upgrade and bump minimum version to fix it.

Also remove some version numbers to make sure we're using the Qt 6 versions of the components and not some backwards compatible ones from Qt 5.