### PR TITLE
Inline move list

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -13,10 +13,10 @@ if (ANDROID)
     # Disable precompile headers because there is a confict on android where it links
     # some code as PIC and some as non-PIC and can't combine them.
     set(PCH_ENABLED OFF)
-    message("-- wisdom-chess; ; precompiled headers disabled")
+    message("-- wisdom-chess: precompiled headers disabled")
 else()
     set(PCH_ENABLED ON)
-    message("-- wisdom-chess; ; precompiled headers enabled")
+    message("-- wisdom-chess: precompiled headers enabled")
 endif()
 
 if (NOT WIN32)

--- a/engine/src/board.hpp
+++ b/engine/src/board.hpp
@@ -199,7 +199,7 @@ namespace wisdom
         void update_move_clock (Color who, Piece orig_src_piece_type, Move mv, UndoMove& undo_state)
         {
             undo_state.half_move_clock = my_half_move_clock;
-            if (is_any_capturing_move (mv) || orig_src_piece_type == Piece::Pawn)
+            if (mv.is_any_capturing () || orig_src_piece_type == Piece::Pawn)
                 my_half_move_clock = 0;
             else
                 my_half_move_clock++;

--- a/engine/src/board_builder.cpp
+++ b/engine/src/board_builder.cpp
@@ -81,7 +81,7 @@ namespace wisdom
             return;
 
         auto coord = make_coord (row, col);
-        my_squares[coord_index (coord)] = make_piece (who, piece_type);
+        my_squares[coord_index (coord)] = ColoredPiece::make (who, piece_type);
 
         if (piece_type == Piece::King)
             my_king_positions[color_index (who)] = coord;

--- a/engine/src/board_code.cpp
+++ b/engine/src/board_code.cpp
@@ -87,20 +87,20 @@ namespace wisdom
 
     void BoardCode::apply_move (const Board& board, Move move)
     {
-        Coord src = move_src (move);
-        Coord dst = move_dst (move);
+        Coord src = move.get_src ();
+        Coord dst = move.get_dst ();
 
         ColoredPiece src_piece = board.piece_at (src);
 
         Piece src_piece_type = piece_type (src_piece);
         Color src_piece_color = piece_color (src_piece);
 
-        if (is_special_castling_move (move))
+        if (move.is_castling ())
         {
             int src_col, dst_col;
             int row;
 
-            if (is_castling_move_on_king_side (move))
+            if (move.is_castling_on_kingside ())
             {
                 dst_col = Kingside_Castled_Rook_Column;
                 src_col = Last_Column;
@@ -117,7 +117,7 @@ namespace wisdom
             remove_piece (rook_src);
             add_piece (make_coord (row, dst_col), rook);
         }
-        else if (is_special_en_passant_move (move))
+        else if (move.is_en_passant ())
         {
             // subtract horizontal pawn and add no piece there:
             Coord taken_pawn_coord = en_passant_taken_pawn_coord (src, dst);
@@ -127,35 +127,35 @@ namespace wisdom
         remove_piece (src);
         add_piece (dst, src_piece);
 
-        if (is_promoting_move (move))
+        if (move.is_promoting ())
         {
             assert (src_piece_type == Piece::Pawn);
-            add_piece (dst, move_get_promoted_piece (move));
+            add_piece (dst, move.get_promoted_piece ());
         }
     }
 
     void BoardCode::unapply_move (const Board& board,
                                   Move move, const UndoMove& undo_state)
     {
-        Coord src = move_src (move);
-        Coord dst = move_dst (move);
+        Coord src = move.get_src ();
+        Coord dst = move.get_dst ();
 
         ColoredPiece src_piece = board.piece_at (dst);
 
         Color src_piece_color = piece_color (src_piece);
         Color opponent_color = color_invert (src_piece_color);
 
-        if (is_promoting_move (move))
+        if (move.is_promoting ())
         {
             src_piece = make_piece (src_piece_color, Piece::Pawn);
         }
 
-        if (is_special_castling_move (move))
+        if (move.is_castling ())
         {
             int8_t src_col, dst_col;
             int8_t row;
 
-            if (is_castling_move_on_king_side (move))
+            if (move.is_castling_on_kingside ())
             {
                 dst_col = Kingside_Castled_Rook_Column;
                 src_col = Last_Column;
@@ -176,13 +176,13 @@ namespace wisdom
         add_piece (src, src_piece);
         remove_piece (dst);
 
-        if (is_normal_capturing_move (move))
+        if (move.is_normal_capturing ())
         {
             ColoredPiece captured = captured_material (undo_state, opponent_color);
             add_piece (dst, captured);
         }
 
-        if (is_special_en_passant_move (move))
+        if (move.is_en_passant ())
         {
             ColoredPiece captured_pawn = make_piece (opponent_color, Piece::Pawn);
             Coord taken_pawn_coord = en_passant_taken_pawn_coord (src, dst);

--- a/engine/src/board_code.cpp
+++ b/engine/src/board_code.cpp
@@ -113,7 +113,7 @@ namespace wisdom
             row = src_piece_color == Color::White ? Last_Row : First_Row;
 
             Coord rook_src = make_coord (row, src_col);
-            ColoredPiece rook = make_piece (src_piece_color, Piece::Rook);
+            ColoredPiece rook = ColoredPiece::make (src_piece_color, Piece::Rook);
             remove_piece (rook_src);
             add_piece (make_coord (row, dst_col), rook);
         }
@@ -147,7 +147,7 @@ namespace wisdom
 
         if (move.is_promoting ())
         {
-            src_piece = make_piece (src_piece_color, Piece::Pawn);
+            src_piece = ColoredPiece::make (src_piece_color, Piece::Pawn);
         }
 
         if (move.is_castling ())
@@ -168,7 +168,7 @@ namespace wisdom
             row = gsl::narrow_cast<int8_t> (src_piece_color == Color::White ? Last_Row : First_Row);
 
             Coord rook_src = make_coord (row, src_col);
-            ColoredPiece rook = make_piece (src_piece_color, Piece::Rook);
+            ColoredPiece rook = ColoredPiece::make (src_piece_color, Piece::Rook);
             add_piece (rook_src, rook);
             remove_piece (make_coord (row, dst_col));
         }
@@ -184,7 +184,7 @@ namespace wisdom
 
         if (move.is_en_passant ())
         {
-            ColoredPiece captured_pawn = make_piece (opponent_color, Piece::Pawn);
+            ColoredPiece captured_pawn = ColoredPiece::make (opponent_color, Piece::Pawn);
             Coord taken_pawn_coord = en_passant_taken_pawn_coord (src, dst);
             add_piece (taken_pawn_coord, captured_pawn);
         }

--- a/engine/src/check.cpp
+++ b/engine/src/check.cpp
@@ -30,16 +30,16 @@ namespace wisdom
         auto king_row = Row (king_coord);
         auto king_col = Column (king_coord);
 
-        if (is_special_castling_move (mv))
+        if (mv.is_castling ())
         {
-            Coord castled_pos = move_dst (mv);
+            Coord castled_pos = mv.get_dst ();
             auto castled_row = Row (castled_pos);
             auto castled_col = Column (castled_pos);
 
             assert (king_row == castled_row);
             assert (king_col == castled_col);
 
-            int8_t direction = is_castling_move_on_king_side (mv) ? -1 : 1;
+            int8_t direction = mv.is_castling_on_kingside () ? -1 : 1;
 
             int8_t plus_one_column = next_column (castled_col, direction);
             int8_t plus_two_column = next_column (plus_one_column, direction);

--- a/engine/src/coord.hpp
+++ b/engine/src/coord.hpp
@@ -2,7 +2,6 @@
 #define WISDOM_CHESS_COORD_H
 
 #include "global.hpp"
-#include "piece.hpp"
 
 namespace wisdom
 {

--- a/engine/src/evaluate.cpp
+++ b/engine/src/evaluate.cpp
@@ -16,7 +16,7 @@ namespace wisdom
             auto king_column = Column<int> (king_pos);
             auto king_row = Row<int> (king_pos);
 
-            auto rook_piece = make_piece (who, Piece::Rook);
+            auto rook_piece = ColoredPiece::make (who, Piece::Rook);
 
             if (king_row != castling_row_for_color (who))
                 return false;

--- a/engine/src/fen_parser.cpp
+++ b/engine/src/fen_parser.cpp
@@ -22,17 +22,17 @@ namespace wisdom
         switch (lower)
         {
             case 'k':
-                return make_piece (who, Piece::King);
+                return ColoredPiece::make (who, Piece::King);
             case 'q':
-                return make_piece (who, Piece::Queen);
+                return ColoredPiece::make (who, Piece::Queen);
             case 'r':
-                return make_piece (who, Piece::Rook);
+                return ColoredPiece::make (who, Piece::Rook);
             case 'b':
-                return make_piece (who, Piece::Bishop);
+                return ColoredPiece::make (who, Piece::Bishop);
             case 'n':
-                return make_piece (who, Piece::Knight);
+                return ColoredPiece::make (who, Piece::Knight);
             case 'p':
-                return make_piece (who, Piece::Pawn);
+                return ColoredPiece::make (who, Piece::Pawn);
             default:
                 throw FenParserError ("Invalid piece type!");
         }

--- a/engine/src/game.cpp
+++ b/engine/src/game.cpp
@@ -166,7 +166,7 @@ namespace wisdom
 
             Move move = move_parse (input_buf, result.get_current_turn ());
 
-            Coord dst = move_dst (move);
+            Coord dst = move.get_dst ();
             ColoredPiece piece = result.my_board->piece_at (dst);
 
             result.move (move);

--- a/engine/src/generate.cpp
+++ b/engine/src/generate.cpp
@@ -60,7 +60,7 @@ namespace wisdom
                     if (!is_valid_column (k_col + col))
                         continue;
 
-                    Move knight_move = Move::make_default (k_row + row, k_col + col, row, col);
+                    Move knight_move = Move::make (k_row + row, k_col + col, row, col);
                     int dst_row = k_row + row;
                     int dst_col = k_col + col;
                     auto index = coord_index (dst_row, dst_col);
@@ -165,7 +165,7 @@ namespace wisdom
                 if (!is_valid_column (col))
                     continue;
 
-                append_move (board, moves, Move::make_default (piece_row, piece_col, row, col));
+                append_move (board, moves, Move::make (piece_row, piece_col, row, col));
             }
         }
 
@@ -195,8 +195,7 @@ namespace wisdom
             {
                 ColoredPiece piece = board.piece_at (row, piece_col);
 
-                append_move (board, moves,
-                             Move::make_default (piece_row, piece_col, row, piece_col));
+                append_move (board, moves, Move::make (piece_row, piece_col, row, piece_col));
 
                 if (piece_type (piece) != Piece::None)
                     break;
@@ -206,8 +205,7 @@ namespace wisdom
             {
                 ColoredPiece piece = board.piece_at (piece_row, col);
 
-                append_move (board, moves,
-                             Move::make_default (piece_row, piece_col, piece_row, col));
+                append_move (board, moves, Move::make (piece_row, piece_col, piece_row, col));
 
                 if (piece_type (piece) != Piece::None)
                     break;
@@ -230,7 +228,7 @@ namespace wisdom
                 {
                     ColoredPiece piece = board.piece_at (row, col);
 
-                    append_move (board, moves, Move::make_default (piece_row, piece_col, row, col));
+                    append_move (board, moves, Move::make (piece_row, piece_col, row, col));
 
                     if (piece != Piece_And_Color_None)
                         break;
@@ -306,7 +304,7 @@ namespace wisdom
 
         // single move
         if (piece_type (board.piece_at (row, piece_col)) == Piece::None)
-            all_pawn_moves[0] = Move::make_default (piece_row, piece_col, row, piece_col);
+            all_pawn_moves[0] = Move::make (piece_row, piece_col, row, piece_col);
 
         // double move
         if (is_pawn_unmoved (board, piece_row, piece_col))
@@ -316,7 +314,7 @@ namespace wisdom
             if (all_pawn_moves[0].has_value () &&
                 board.piece_at (double_row, piece_col) == Piece_And_Color_None)
             {
-                all_pawn_moves[1] = Move::make_default (piece_row, piece_col, double_row, piece_col);
+                all_pawn_moves[1] = Move::make (piece_row, piece_col, double_row, piece_col);
             }
         }
 

--- a/engine/src/generate.cpp
+++ b/engine/src/generate.cpp
@@ -60,7 +60,7 @@ namespace wisdom
                     if (!is_valid_column (k_col + col))
                         continue;
 
-                    Move knight_move = make_regular_move (k_row + row, k_col + col, row, col);
+                    Move knight_move = Move::make_default (k_row + row, k_col + col, row, col);
                     int dst_row = k_row + row;
                     int dst_col = k_col + col;
                     auto index = coord_index (dst_row, dst_col);
@@ -99,8 +99,8 @@ namespace wisdom
         // check for an intervening piece
         int direction;
 
-        Coord src = move_src (move);
-        Coord dst = move_dst (move);
+        Coord src = move.get_src ();
+        Coord dst = move.get_dst ();
 
         ColoredPiece piece3 = make_piece (Color::None, Piece::None);
 
@@ -125,16 +125,16 @@ namespace wisdom
         -> Move
     {
         bool is_capture = (piece_type (dst_piece) != Piece::None);
-        if (is_capture && !is_special_en_passant_move (move) && !is_normal_capturing_move (move))
-            move = copy_move_with_capture (move);
+        if (is_capture && !move.is_en_passant () && !move.is_normal_capturing ())
+            move = move.with_capture ();
 
         return move;
     }
 
     static void append_move (const Board &board, MoveList& list, Move move) noexcept
     {
-        Coord src = move_src (move);
-        Coord dst = move_dst (move);
+        Coord src = move.get_src ();
+        Coord dst = move.get_dst ();
 
         ColoredPiece src_piece = board.piece_at (src);
         ColoredPiece dst_piece = board.piece_at (dst);
@@ -165,20 +165,20 @@ namespace wisdom
                 if (!is_valid_column (col))
                     continue;
 
-                append_move (board, moves, make_regular_move (piece_row, piece_col, row, col));
+                append_move (board, moves, Move::make_default (piece_row, piece_col, row, col));
             }
         }
 
         if (board.able_to_castle ( who, Castle_Queenside) && piece_col == King_Column)
         {
-            Move queenside_castle = make_special_castling_move (piece_row, piece_col, piece_row, piece_col - 2);
+            Move queenside_castle = Move::make_castling (piece_row, piece_col, piece_row, piece_col - 2);
             if (valid_castling_move (board, queenside_castle))
                 append_move (board, moves, queenside_castle);
         }
 
         if (board.able_to_castle ( who, Castle_Kingside) && piece_col == King_Column)
         {
-            Move kingside_castle = make_special_castling_move (piece_row, piece_col, piece_row, piece_col + 2);
+            Move kingside_castle = Move::make_castling (piece_row, piece_col, piece_row, piece_col + 2);
             if (valid_castling_move (board, kingside_castle))
                 append_move (board, moves, kingside_castle);
         }
@@ -196,7 +196,7 @@ namespace wisdom
                 ColoredPiece piece = board.piece_at (row, piece_col);
 
                 append_move (board, moves,
-                             make_regular_move (piece_row, piece_col, row, piece_col));
+                             Move::make_default (piece_row, piece_col, row, piece_col));
 
                 if (piece_type (piece) != Piece::None)
                     break;
@@ -207,7 +207,7 @@ namespace wisdom
                 ColoredPiece piece = board.piece_at (piece_row, col);
 
                 append_move (board, moves,
-                             make_regular_move (piece_row, piece_col, piece_row, col));
+                             Move::make_default (piece_row, piece_col, piece_row, col));
 
                 if (piece_type (piece) != Piece::None)
                     break;
@@ -230,7 +230,7 @@ namespace wisdom
                 {
                     ColoredPiece piece = board.piece_at (row, col);
 
-                    append_move (board, moves, make_regular_move (piece_row, piece_col, row, col));
+                    append_move (board, moves, Move::make_default (piece_row, piece_col, row, col));
 
                     if (piece != Piece_And_Color_None)
                         break;
@@ -306,7 +306,7 @@ namespace wisdom
 
         // single move
         if (piece_type (board.piece_at (row, piece_col)) == Piece::None)
-            all_pawn_moves[0] = make_regular_move (piece_row, piece_col, row, piece_col);
+            all_pawn_moves[0] = Move::make_default (piece_row, piece_col, row, piece_col);
 
         // double move
         if (is_pawn_unmoved (board, piece_row, piece_col))
@@ -316,7 +316,7 @@ namespace wisdom
             if (all_pawn_moves[0].has_value () &&
                 board.piece_at (double_row, piece_col) == Piece_And_Color_None)
             {
-                all_pawn_moves[1] = make_regular_move (piece_row, piece_col, double_row, piece_col);
+                all_pawn_moves[1] = Move::make_default (piece_row, piece_col, double_row, piece_col);
             }
         }
 
@@ -334,9 +334,9 @@ namespace wisdom
                 piece_color (target_piece) != who)
             {
                 if (c_dir == -1)
-                    all_pawn_moves[2] = make_normal_capturing_move (piece_row, piece_col, row, take_col);
+                    all_pawn_moves[2] = Move::make_normal_capturing (piece_row, piece_col, row, take_col);
                 else
-                    all_pawn_moves[3] = make_normal_capturing_move (piece_row, piece_col, row, take_col);
+                    all_pawn_moves[3] = Move::make_normal_capturing (piece_row, piece_col, row, take_col);
             }
         }
 
@@ -353,7 +353,7 @@ namespace wisdom
                     if (optional_move.has_value ())
                     {
                         auto move = *optional_move;
-                        move = copy_move_with_promotion (move, promoted_piece);
+                        move = move.with_promotion (promoted_piece);
                         append_move (board, moves, move);
                     }
                 }
@@ -390,7 +390,7 @@ namespace wisdom
         assert (piece_type (take_piece) == Piece::Pawn);
         assert (piece_color (take_piece) == color_invert (who));
 
-        Move new_move = make_special_en_passant_move (piece_row, piece_col, take_row, take_col);
+        Move new_move = Move::make_en_passant (piece_row, piece_col, take_row, take_col);
 
         append_move (board, moves, new_move);
     }
@@ -446,19 +446,19 @@ namespace wisdom
 
     static int material_diff (const Board& board, Move move)
     {
-        assert (is_any_capturing_move (move));
+        assert (move.is_any_capturing ());
 
-        if (is_special_en_passant_move (move))
+        if (move.is_en_passant ())
         {
             return 0;
         }
         else
         {
             int a_material_src = Material::weight (
-                piece_type (board.piece_at (move_src (move)))
+                piece_type (board.piece_at (move.get_src ()))
             );
             int a_material_dst = Material::weight (
-                piece_type (board.piece_at (move_dst (move)))
+                piece_type (board.piece_at (move.get_dst ()))
             );
             return a_material_dst - a_material_src;
         }
@@ -466,13 +466,13 @@ namespace wisdom
 
     static constexpr auto promoting_or_coord_compare (const Move& a, const Move& b) -> bool
     {
-        bool a_is_promoting = is_promoting_move (a);
-        bool b_is_promoting = is_promoting_move (b);
+        bool a_is_promoting = a.is_promoting ();
+        bool b_is_promoting = b.is_promoting ();
 
         if (a_is_promoting && b_is_promoting)
         {
-            return Material::weight (piece_type (move_get_promoted_piece (a))) >
-                Material::weight (piece_type (move_get_promoted_piece (b)));
+            return Material::weight (piece_type (a.get_promoted_piece ())) >
+                Material::weight (piece_type (b.get_promoted_piece ()));
         }
         else if (a_is_promoting && !b_is_promoting)
         {
@@ -484,19 +484,19 @@ namespace wisdom
         }
 
         // return coordinate diff so order is consistent:
-        Coord a_coord = move_src (a);
-        Coord b_coord = move_src (b);
+        Coord a_coord = a.get_src ();
+        Coord b_coord = b.get_src ();
 
         if (a_coord != b_coord)
             return coord_index (a_coord) < coord_index (b_coord);
         else
-            return coord_index (move_dst (a)) < coord_index (move_dst (b));
+            return coord_index (a.get_dst ()) < coord_index (b.get_dst ());
     }
 
     auto MoveGeneration::compare_moves (const Move& a, const Move& b) const -> bool
     {
-        bool a_is_capturing = is_any_capturing_move (a);
-        bool b_is_capturing = is_any_capturing_move (b);
+        bool a_is_capturing = a.is_any_capturing ();
+        bool b_is_capturing = b.is_any_capturing ();
 
         if (!a_is_capturing && !b_is_capturing)
         {

--- a/engine/src/generate.cpp
+++ b/engine/src/generate.cpp
@@ -102,7 +102,7 @@ namespace wisdom
         Coord src = move.get_src ();
         Coord dst = move.get_dst ();
 
-        ColoredPiece piece3 = make_piece (Color::None, Piece::None);
+        ColoredPiece piece3 = ColoredPiece::make (Color::None, Piece::None);
 
         // find which direction the king was castling in
         direction = (Column (dst) - Column (src)) / 2;
@@ -343,7 +343,7 @@ namespace wisdom
         {
             for (auto promotable_piece_type : All_Promotable_Piece_Types)
             {
-                auto promoted_piece = make_piece (who, promotable_piece_type);
+                auto promoted_piece = ColoredPiece::make (who, promotable_piece_type);
 
                 // promotion moves dont include en passant
                 for (auto& optional_move: all_pawn_moves)

--- a/engine/src/generate.hpp
+++ b/engine/src/generate.hpp
@@ -21,7 +21,7 @@ namespace wisdom
     class MoveGenerator final
     {
     private:
-        unique_ptr<MoveListAllocator> my_move_list_allocator = make_unique<MoveListAllocator>();
+        unique_ptr<MoveListAllocator> my_move_list_allocator = MoveListAllocator::make_unique ();
         array<unique_ptr<MoveList>, Num_Squares> my_knight_moves {};
 
         void knight_move_list_init ();

--- a/engine/src/material.cpp
+++ b/engine/src/material.cpp
@@ -17,8 +17,8 @@ namespace wisdom
                                                  Color first_bishop_color, Color second_bishop_color)
         -> bool
     {
-        auto first_bishop = make_piece (first_bishop_color, Piece::Bishop);
-        auto second_bishop = make_piece (second_bishop_color, Piece::Bishop);
+        auto first_bishop = ColoredPiece::make (first_bishop_color, Piece::Bishop);
+        auto second_bishop = ColoredPiece::make (second_bishop_color, Piece::Bishop);
         auto first_coord = board.find_first_coord_with_piece (first_bishop);
 
         auto starting_at = first_bishop_color == second_bishop_color ?

--- a/engine/src/material.hpp
+++ b/engine/src/material.hpp
@@ -14,7 +14,7 @@ namespace wisdom
         int my_score[Num_Players] {};
 
         // Count of pieces on either side:
-        array<array<int, Num_Pieces>, Num_Players> my_piece_count {};
+        array<array<int, Num_Piece_Types>, Num_Players> my_piece_count {};
 
     public:
         Material () = default;

--- a/engine/src/move.cpp
+++ b/engine/src/move.cpp
@@ -610,10 +610,10 @@ namespace wisdom
             throw ParseMoveException ("Error parsing move: " + str);
 
         auto result = *optional_result;
+        auto move_category = get_move_category (result);
         if (color == Color::None &&
-            result.move_category != MoveCategory::NormalCapturing
-            &&
-            result.move_category != MoveCategory::NormalMovement)
+            move_category != MoveCategory::NormalCapturing &&
+            move_category != MoveCategory::NormalMovement)
         {
             throw ParseMoveException ("Invalid type of move in parse_simple_move");
         }

--- a/engine/src/move.cpp
+++ b/engine/src/move.cpp
@@ -44,7 +44,7 @@ namespace wisdom
 
         if (undo)
         {
-            ColoredPiece taken_pawn = make_piece (color_invert (who), Piece::Pawn);
+            ColoredPiece taken_pawn = ColoredPiece::make (color_invert (who), Piece::Pawn);
             board->set_piece (taken_pawn_pos, taken_pawn);
 
             return Piece_And_Color_None; // restore empty square where piece was replaced
@@ -112,7 +112,7 @@ namespace wisdom
         auto rook_src = rook_move.get_src ();
         auto rook_dst = rook_move.get_dst ();
 
-        auto empty_piece = make_piece (Color::None, Piece::None);
+        auto empty_piece = ColoredPiece::make (Color::None, Piece::None);
 
         if constexpr (undo)
         {
@@ -335,7 +335,7 @@ namespace wisdom
         {
             src_piece = move.get_promoted_piece ();
             my_material.add (src_piece);
-            my_material.remove (make_piece (who, Piece::Pawn));
+            my_material.remove (ColoredPiece::make (who, Piece::Pawn));
         }
 
         // check for en passant
@@ -413,12 +413,12 @@ namespace wisdom
         assert (piece_type (src_piece) != Piece::None);
         assert (piece_color (src_piece) == who);
         if (dst_piece_type != Piece::None)
-            dst_piece = make_piece (opponent, dst_piece_type);
+            dst_piece = ColoredPiece::make (opponent, dst_piece_type);
 
         // check for promotion
         if (move.is_promoting ())
         {
-            src_piece = make_piece (piece_color (src_piece), Piece::Pawn);
+            src_piece = ColoredPiece::make (piece_color (src_piece), Piece::Pawn);
             my_material.remove (orig_src_piece);
             my_material.add (src_piece);
         }
@@ -564,26 +564,26 @@ namespace wisdom
         }
 
         // grab extra identifiers describing the move
-        ColoredPiece promoted = make_piece (Color::None, Piece::None);
+        ColoredPiece promoted = ColoredPiece::make (Color::None, Piece::None);
         if (rest == "EP")
         {
             en_passant = true;
         }
         else if (rest == "(Q)")
         {
-            promoted = make_piece (who, Piece::Queen);
+            promoted = ColoredPiece::make (who, Piece::Queen);
         }
         else if (rest == "(N)")
         {
-            promoted = make_piece (who, Piece::Knight);
+            promoted = ColoredPiece::make (who, Piece::Knight);
         }
         else if (rest == "(B)")
         {
-            promoted = make_piece (who, Piece::Bishop);
+            promoted = ColoredPiece::make (who, Piece::Bishop);
         }
         else if (rest == "(R)")
         {
-            promoted = make_piece (who, Piece::Rook);
+            promoted = ColoredPiece::make (who, Piece::Rook);
         }
 
         if (piece_type (promoted) != Piece::None)
@@ -697,7 +697,7 @@ namespace wisdom
                         return Move::make_en_passant (src, dst);
 
                     if (need_pawn_promotion (Row<int> (dst), who) && promoted_piece.has_value ())
-                        return move.with_promotion (make_piece (who, *promoted_piece));
+                        return move.with_promotion (ColoredPiece::make (who, *promoted_piece));
                 }
                 break;
 

--- a/engine/src/move.cpp
+++ b/engine/src/move.cpp
@@ -95,7 +95,7 @@ namespace wisdom
             };
         }
 
-        return Move::make_default (src_row, src_col, dst_row, dst_col);
+        return Move::make (src_row, src_col, dst_row, dst_col);
     }
 
     template <bool undo>
@@ -557,7 +557,7 @@ namespace wisdom
         }
 
         string rest { tmp.substr (offset) };
-        Move move = Move::make_default (*src, *dst);
+        Move move = Move::make (*src, *dst);
         if (is_capturing)
         {
             move = move.with_capture ();
@@ -678,7 +678,7 @@ namespace wisdom
             return {};
 
         // make capturing if dst piece is not none
-        Move move = Move::make_default (src, dst);
+        Move move = Move::make (src, dst);
         if (dst_piece != Piece_And_Color_None)
             move = move.with_capture ();
 

--- a/engine/src/move.hpp
+++ b/engine/src/move.hpp
@@ -225,7 +225,7 @@ namespace wisdom
             auto piece = piece_from_int (promoted_piece & 0xf);
             auto color = piece == Piece::None ? Color::None :
                 (promoted_piece & 0x10) == 0x10 ? Color::Black : Color::White;
-            return make_piece (color, piece);
+            return ColoredPiece::make (color, piece);
         }
 
         [[nodiscard]] constexpr auto is_en_passant () const noexcept
@@ -270,11 +270,11 @@ namespace wisdom
     {
         if (undo_state.category == MoveCategory::NormalCapturing)
         {
-            return make_piece (opponent, undo_state.taken_piece_type);
+            return ColoredPiece::make (opponent, undo_state.taken_piece_type);
         }
         else if (undo_state.category == MoveCategory::EnPassant)
         {
-            return make_piece (opponent, Piece::Pawn);
+            return ColoredPiece::make (opponent, Piece::Pawn);
         }
         else
         {

--- a/engine/src/move.hpp
+++ b/engine/src/move.hpp
@@ -99,7 +99,7 @@ namespace wisdom
         int8_t move_category_and_packed_flag;
 
     public:
-        [[nodiscard]] static constexpr auto make_default (Coord src, Coord dst) noexcept
+        [[nodiscard]] static constexpr auto make (Coord src, Coord dst) noexcept
         -> Move
         {
             return Move {
@@ -110,21 +110,21 @@ namespace wisdom
             };
         }
 
-        [[nodiscard]] static constexpr auto make_default (int src_row, int src_col,
-                                                          int dst_row, int dst_col) noexcept
+        [[nodiscard]] static constexpr auto make (int src_row, int src_col,
+                                                  int dst_row, int dst_col) noexcept
             -> Move
         {
             Coord src = make_coord (src_row, src_col);
             Coord dst = make_coord (dst_row, dst_col);
 
-            return make_default (src, dst);
+            return make (src, dst);
         }
 
         [[nodiscard]] static constexpr auto make_normal_capturing (int src_row, int src_col,
                                                                    int dst_row, int dst_col) noexcept
             -> Move
         {
-            Move move = Move::make_default (src_row, src_col, dst_row, dst_col);
+            Move move = Move::make (src_row, src_col, dst_row, dst_col);
             move.move_category_and_packed_flag = to_int8 (MoveCategory::NormalCapturing);
             return move;
         }
@@ -133,7 +133,7 @@ namespace wisdom
                                                            int dst_row, int dst_col) noexcept
             -> Move
         {
-            Move move = Move::make_default (src_row, src_col, dst_row, dst_col);
+            Move move = Move::make (src_row, src_col, dst_row, dst_col);
             move.move_category_and_packed_flag = to_int8 (MoveCategory::Castling);
             return move;
         }
@@ -148,7 +148,7 @@ namespace wisdom
                                                              int dst_row, int dst_col) noexcept
             -> Move
         {
-            Move move = make_default (src_row, src_col, dst_row, dst_col);
+            Move move = make (src_row, src_col, dst_row, dst_col);
             move.move_category_and_packed_flag = to_int8 (MoveCategory::EnPassant);
             return move;
         }
@@ -200,7 +200,7 @@ namespace wisdom
         {
             assert (move_category_and_packed_flag == to_int8 (MoveCategory::Default));
 
-            Move result = Move::make_default (get_src (), get_dst ());
+            Move result = Move::make (get_src (), get_dst ());
             result.move_category_and_packed_flag = to_int8 (MoveCategory::NormalCapturing);
             return result;
         }

--- a/engine/src/move.hpp
+++ b/engine/src/move.hpp
@@ -11,7 +11,7 @@ namespace wisdom
 
     using CastlingState = uint8_t;
 
-    static constexpr size_t Max_Packed_Capacity_In_Move = 0x0fffFFFFL; // 28 bit max
+    static constexpr size_t Max_Packed_Capacity_In_Move = 0x001FFFFFL; // 21 bit max
 
     constexpr uint8_t
             Castle_None = 0b000U;      // still eligible to castle on both sides
@@ -31,6 +31,7 @@ namespace wisdom
         NormalCapturing = 1,
         EnPassant = 2,
         Castling = 3,
+        PackedCapacity = 4,
     };
 
     struct UndoMove
@@ -168,7 +169,7 @@ namespace wisdom
                 .src = gsl::narrow_cast<int8_t> (size & 0x7f),
                 .dst = gsl::narrow_cast<int8_t> ((size >> 7) & 0x7f),
                 .promoted_piece = gsl::narrow_cast<int8_t> ((size >> 14) & 0x7f),
-                .move_category = gsl::narrow_cast<int8_t> ((size >> 21) & 0x7f),
+                .move_category = to_int8 (MoveCategory::PackedCapacity),
             };
         }
 
@@ -255,10 +256,10 @@ namespace wisdom
         [[nodiscard]] constexpr auto to_unpacked_capacity () const noexcept
             -> size_t
         {
+            assert (get_move_category () == MoveCategory::PackedCapacity);
             return src |
                 (dst << 7) |
-                (promoted_piece << 14) |
-                (move_category << 21);
+                (promoted_piece << 14);
         }
     };
 

--- a/engine/src/move.hpp
+++ b/engine/src/move.hpp
@@ -11,6 +11,8 @@ namespace wisdom
 
     using CastlingState = uint8_t;
 
+    static constexpr size_t Max_Packed_Capacity_In_Move = 0x0fffFFFFL; // 28 bit max
+
     constexpr uint8_t
             Castle_None = 0b000U;      // still eligible to castle on both sides
     constexpr uint8_t
@@ -212,22 +214,22 @@ namespace wisdom
     [[nodiscard]] inline auto make_move_with_packed_capacity (size_t size) noexcept
         -> Move
     {
-        assert (size <= 0xffffFFFF);
+        assert (size <= Max_Packed_Capacity_In_Move);
         return {
             .src = gsl::narrow_cast<int8_t> (size & 0x7f),
-            .dst = gsl::narrow_cast<int8_t> ((size >> 8) & 0x7f),
-            .promoted_piece = gsl::narrow_cast<int8_t> ((size >> 16) & 0x7f),
-            .move_category_and_packed_flag = gsl::narrow_cast<int8_t> ((size >> 24) & 0x7f),
+            .dst = gsl::narrow_cast<int8_t> ((size >> 7) & 0x7f),
+            .promoted_piece = gsl::narrow_cast<int8_t> ((size >> 14) & 0x7f),
+            .move_category_and_packed_flag = gsl::narrow_cast<int8_t> ((size >> 21) & 0x7f),
         };
     }
 
-    [[nodiscard]] inline auto extract_packed_capacity_from_move (Move move) noexcept
+    [[nodiscard]] inline auto unpack_capacity_from_move (Move move) noexcept
         -> size_t
     {
         return move.src |
-            (move.dst << 8) |
-            (move.promoted_piece << 16) |
-            (move.move_category_and_packed_flag << 24);
+            (move.dst << 7) |
+            (move.promoted_piece << 14) |
+            (move.move_category_and_packed_flag << 21);
     }
 
     [[nodiscard]] constexpr auto make_normal_capturing_move (int src_row, int src_col,

--- a/engine/src/move.hpp
+++ b/engine/src/move.hpp
@@ -96,7 +96,7 @@ namespace wisdom
         int8_t src;
         int8_t dst;
         int8_t promoted_piece;
-        int8_t move_category_and_packed_flag;
+        int8_t move_category;
 
     public:
         [[nodiscard]] static constexpr auto make (Coord src, Coord dst) noexcept
@@ -106,7 +106,7 @@ namespace wisdom
                 .src = gsl::narrow_cast<int8_t> (coord_index (src)),
                 .dst = gsl::narrow_cast<int8_t> (coord_index (dst)),
                 .promoted_piece = gsl::narrow_cast<int8_t> (0),
-                .move_category_and_packed_flag = gsl::narrow_cast<int8_t> (0),
+                .move_category = gsl::narrow_cast<int8_t> (0),
             };
         }
 
@@ -125,7 +125,7 @@ namespace wisdom
             -> Move
         {
             Move move = Move::make (src_row, src_col, dst_row, dst_col);
-            move.move_category_and_packed_flag = to_int8 (MoveCategory::NormalCapturing);
+            move.move_category = to_int8 (MoveCategory::NormalCapturing);
             return move;
         }
 
@@ -134,7 +134,7 @@ namespace wisdom
             -> Move
         {
             Move move = Move::make (src_row, src_col, dst_row, dst_col);
-            move.move_category_and_packed_flag = to_int8 (MoveCategory::Castling);
+            move.move_category = to_int8 (MoveCategory::Castling);
             return move;
         }
 
@@ -149,7 +149,7 @@ namespace wisdom
             -> Move
         {
             Move move = make (src_row, src_col, dst_row, dst_col);
-            move.move_category_and_packed_flag = to_int8 (MoveCategory::EnPassant);
+            move.move_category = to_int8 (MoveCategory::EnPassant);
             return move;
         }
 
@@ -168,7 +168,7 @@ namespace wisdom
                 .src = gsl::narrow_cast<int8_t> (size & 0x7f),
                 .dst = gsl::narrow_cast<int8_t> ((size >> 7) & 0x7f),
                 .promoted_piece = gsl::narrow_cast<int8_t> ((size >> 14) & 0x7f),
-                .move_category_and_packed_flag = gsl::narrow_cast<int8_t> ((size >> 21) & 0x7f),
+                .move_category = gsl::narrow_cast<int8_t> ((size >> 21) & 0x7f),
             };
         }
 
@@ -198,16 +198,16 @@ namespace wisdom
         [[nodiscard]] constexpr auto with_capture () const noexcept
             -> Move
         {
-            assert (move_category_and_packed_flag == to_int8 (MoveCategory::Default));
+            assert (move_category == to_int8 (MoveCategory::Default));
 
             Move result = Move::make (get_src (), get_dst ());
-            result.move_category_and_packed_flag = to_int8 (MoveCategory::NormalCapturing);
+            result.move_category = to_int8 (MoveCategory::NormalCapturing);
             return result;
         }
 
         [[nodiscard]] constexpr auto get_move_category () const -> MoveCategory
         {
-            return move_category_from_int (move_category_and_packed_flag);
+            return move_category_from_int (move_category);
         }
 
         [[nodiscard]] constexpr auto is_normal_capturing () const -> bool
@@ -258,7 +258,7 @@ namespace wisdom
             return src |
                 (dst << 7) |
                 (promoted_piece << 14) |
-                (move_category_and_packed_flag << 21);
+                (move_category << 21);
         }
     };
 
@@ -299,7 +299,7 @@ namespace wisdom
         return a.src == b.src &&
                a.dst == b.dst &&
                a.promoted_piece == b.promoted_piece &&
-               a.move_category_and_packed_flag == b.move_category_and_packed_flag;
+               a.move_category == b.move_category;
     }
 
     constexpr auto operator== (Move a, Move b) noexcept

--- a/engine/src/move_list.hpp
+++ b/engine/src/move_list.hpp
@@ -28,7 +28,7 @@ namespace wisdom
 
         static void move_list_append (MoveListPtr& move_list_ptr, std::size_t position, Move move) noexcept
         {
-            size_t old_capacity = extract_packed_capacity_from_move (move_list_ptr[0]);
+            size_t old_capacity = unpack_capacity_from_move (move_list_ptr[0]);
             assert (position <= old_capacity);
 
             if (position == old_capacity)

--- a/engine/src/move_list.hpp
+++ b/engine/src/move_list.hpp
@@ -8,59 +8,43 @@
 
 namespace wisdom
 {
-    struct move_list
-    {
-        Move* move_array;
-        std::size_t capacity;
-    };
+    using MoveListPtr = unique_ptr<Move[]>;
 
     class MoveListAllocator
     {
     private:
-        vector<unique_ptr<move_list>> my_move_list_ptrs;
+        vector<MoveListPtr> my_move_list_ptrs;
 
     public:
-        ~MoveListAllocator()
-        {
-            for (auto& ptr : my_move_list_ptrs)
-            {
-                if (ptr && ptr->move_array)
-                {
-                    free (ptr->move_array);
-                    ptr->move_array = nullptr;
-                }
-            }
-        }
-
         static constexpr std::size_t Initial_Size = 16;
         static constexpr std::size_t Size_Increment = 32;
 
-        static auto default_alloc_move_list () -> unique_ptr<move_list>
+        static auto default_alloc_move_list () -> MoveListPtr
         {
-            auto list = new move_list ();
-            list->move_array = (Move*)malloc (sizeof (Move) * MoveListAllocator::Initial_Size);
-            list->capacity = MoveListAllocator::Initial_Size;
-
-            return unique_ptr<move_list> { list };
+            auto new_list = make_unique<Move[]> (Initial_Size + 1);
+            new_list[0] = make_move_with_packed_capacity (Initial_Size);
+            return new_list;
         }
 
-        static void move_list_append (move_list& list, std::size_t position, Move move) noexcept
+        static void move_list_append (MoveListPtr& move_list_ptr, std::size_t position, Move move) noexcept
         {
-            assert (position <= list.capacity);
+            size_t old_capacity = extract_packed_capacity_from_move (move_list_ptr[0]);
+            assert (position <= old_capacity);
 
-            if (position == list.capacity)
+            if (position == old_capacity)
             {
-                list.capacity += MoveListAllocator::Size_Increment;
+                size_t new_capacity = old_capacity + MoveListAllocator::Size_Increment;
 
-                std::size_t new_capacity_in_bytes = list.capacity * sizeof (Move);
-                list.move_array = (Move*)realloc (list.move_array, new_capacity_in_bytes);
+                auto new_list = make_unique<Move[]> (new_capacity + 1);
+                new_list[0] = make_move_with_packed_capacity (new_capacity);
+                std::copy (&move_list_ptr[1], &move_list_ptr[1] + old_capacity, &new_list[1]);
+                move_list_ptr = std::move (new_list);
             }
 
-            assert (list.move_array != nullptr);
-            list.move_array[position] = move;
+            move_list_ptr[position + 1] = move;
         }
 
-        auto alloc_move_list() noexcept -> unique_ptr<move_list>
+        auto alloc_move_list() noexcept -> MoveListPtr
         {
             if (!my_move_list_ptrs.empty ())
             {
@@ -72,7 +56,7 @@ namespace wisdom
             return default_alloc_move_list ();
         }
 
-        void dealloc_move_list (unique_ptr<move_list> move_list) noexcept
+        void dealloc_move_list (MoveListPtr move_list) noexcept
         {
             if (move_list != nullptr)
                 my_move_list_ptrs.emplace_back (std::move (move_list));
@@ -82,7 +66,7 @@ namespace wisdom
     class MoveList
     {
     private:
-        unique_ptr<move_list> my_moves_list;
+        MoveListPtr my_moves_list;
         std::size_t my_size = 0;
         observer_ptr<MoveListAllocator> my_allocator;
 
@@ -101,17 +85,9 @@ namespace wisdom
 
         ~MoveList () 
         {
-            if (my_moves_list != nullptr)
+            if (my_moves_list != nullptr && my_allocator != nullptr)
             {
-                if (my_allocator != nullptr)
-                {
-                    my_allocator->dealloc_move_list (std::move (my_moves_list));
-                }
-                else
-                {
-                    free (my_moves_list->move_array);
-                    my_moves_list->move_array = nullptr;
-                }
+                my_allocator->dealloc_move_list (std::move (my_moves_list));
             }
         }
 
@@ -127,15 +103,7 @@ namespace wisdom
         MoveList (const MoveList& other) = delete;
         MoveList& operator= (const MoveList& other) = delete;
 
-        MoveList (MoveList&& other) noexcept
-            : my_moves_list { std::move (other.my_moves_list) }
-            , my_size { other.my_size }
-            , my_allocator { other.my_allocator }
-        {
-            other.my_moves_list = nullptr;
-            other.my_size = 0;
-            other.my_allocator = nullptr;
-        }
+        MoveList (MoveList&& other) noexcept = default;
 
         // Implement std::swappable
         friend void swap (MoveList& first, MoveList& second) noexcept
@@ -150,16 +118,11 @@ namespace wisdom
             std::swap (my_size, other.my_size);
         }
 
-        MoveList& operator= (MoveList&& other) noexcept
-        {
-            MoveList copy = std::move (other);
-            copy.swap (*this);
-            return *this;
-        }
+        MoveList& operator= (MoveList&& other) noexcept = default;
 
         void push_back (Move move) noexcept
         {
-            MoveListAllocator::move_list_append (*my_moves_list, my_size, move);
+            MoveListAllocator::move_list_append (my_moves_list, my_size, move);
             my_size++;
         }
 
@@ -171,37 +134,37 @@ namespace wisdom
 
         [[nodiscard]] auto begin () const& noexcept -> const Move*
         {
-            return my_moves_list->move_array;
+            return &my_moves_list[1];
         }
         void begin () const&& = delete;
 
         [[nodiscard]] auto end () const& noexcept -> const Move*
         {
-            return my_moves_list->move_array + my_size;
+            return &my_moves_list[1] + my_size;
         }
         void end () const&& = delete;
 
         [[nodiscard]] auto cbegin () const& noexcept -> const Move*
         {
-            return my_moves_list->move_array;
+            return &my_moves_list[1];
         }
         void cbegin () const&& = delete;
 
         [[nodiscard]] auto cend () const& noexcept -> const Move*
         {
-            return my_moves_list->move_array + my_size;
+            return &my_moves_list[1] + my_size;
         }
         void cend () const&& = delete;
 
         [[nodiscard]] auto begin () & noexcept -> Move*
         {
-            return my_moves_list->move_array;
+            return &my_moves_list[1];
         }
         void begin () && = delete;
 
         [[nodiscard]] auto end () & noexcept -> Move*
         {
-            return my_moves_list->move_array + my_size;
+            return &my_moves_list[1] + my_size;
         }
         void end () && = delete;
 
@@ -213,11 +176,6 @@ namespace wisdom
         [[nodiscard]] size_t size () const noexcept
         {
             return my_size;
-        }
-
-        [[nodiscard]] size_t capacity () const noexcept
-        {
-            return my_moves_list->capacity;
         }
 
         [[nodiscard]] auto to_string () const -> string;
@@ -239,13 +197,13 @@ namespace wisdom
 
         [[nodiscard]] auto data () const& noexcept -> Move*
         {
-            return my_moves_list->move_array;
+            return &my_moves_list[1];
         }
         void data () const&& = delete;
 
-        [[nodiscard]] auto ptr () const& noexcept -> move_list*
+        [[nodiscard]] auto ptr () const& noexcept -> const MoveListPtr&
         {
-            return my_moves_list.get ();
+            return my_moves_list;
         }
         void ptr () const&& = delete;
 

--- a/engine/src/piece.hpp
+++ b/engine/src/piece.hpp
@@ -110,6 +110,11 @@ namespace wisdom
         return static_cast<Piece>(integer);
     }
 
+    constexpr auto piece_from_int (int integer) -> Piece
+    {
+        return static_cast<Piece>(integer);
+    }
+
     constexpr auto color_from_int8 (int8_t integer) -> Color
     {
         return static_cast<Color>(integer);

--- a/engine/src/piece.hpp
+++ b/engine/src/piece.hpp
@@ -24,7 +24,7 @@ namespace wisdom
         King
     };
 
-    static constexpr std::size_t Num_Pieces = static_cast<std::size_t> (Piece::King) + 1;
+    static constexpr std::size_t Num_Piece_Types = static_cast<std::size_t> (Piece::King) + 1;
 
     enum class Color : int8_t
     {

--- a/engine/src/position.cpp
+++ b/engine/src/position.cpp
@@ -156,7 +156,7 @@ namespace wisdom
 
         this->remove (who, src, piece);
 
-        switch (move.move_category)
+        switch (get_move_category (move))
         {
             case MoveCategory::NormalMovement:
                 break;

--- a/engine/src/position.cpp
+++ b/engine/src/position.cpp
@@ -163,7 +163,7 @@ namespace wisdom
 
             case MoveCategory::NormalCapturing:
                 {
-                    ColoredPiece taken_piece = make_piece (opponent, undo_state->taken_piece_type);
+                    ColoredPiece taken_piece = ColoredPiece::make (opponent, undo_state->taken_piece_type);
                     Coord taken_piece_coord = dst;
                     this->remove (opponent, taken_piece_coord, taken_piece);
                 }
@@ -172,7 +172,7 @@ namespace wisdom
             case MoveCategory::EnPassant:
                 {
                     Coord taken_pawn_coord = en_passant_taken_pawn_coord (src, dst);
-                    this->remove (opponent, taken_pawn_coord, make_piece (opponent, Piece::Pawn));
+                    this->remove (opponent, taken_pawn_coord, ColoredPiece::make (opponent, Piece::Pawn));
                 }
                 break;
 
@@ -190,7 +190,7 @@ namespace wisdom
 
                     Coord src_rook_coord = make_coord (rook_src_row, rook_src_col);
                     Coord dst_rook_coord = make_coord (rook_src_row, rook_dst_col);
-                    ColoredPiece rook = make_piece (who, Piece::Rook);
+                    ColoredPiece rook = ColoredPiece::make (who, Piece::Rook);
 
                     this->remove (who, src_rook_coord, rook);
                     this->add (who, dst_rook_coord, rook);

--- a/engine/src/position.cpp
+++ b/engine/src/position.cpp
@@ -148,17 +148,17 @@ namespace wisdom
     {
         Color opponent = color_invert (who);
 
-        Coord src = move_src (move);
-        Coord dst = move_dst (move);
+        Coord src = move.get_src ();
+        Coord dst = move.get_dst ();
 
         undo_state->position_score[color_index (who)] = my_score[color_index (who)];
         undo_state->position_score[color_index (opponent)] = my_score[color_index (opponent)];
 
         this->remove (who, src, piece);
 
-        switch (get_move_category (move))
+        switch (move.get_move_category ())
         {
-            case MoveCategory::NormalMovement:
+            case MoveCategory::Default:
                 break;
 
             case MoveCategory::NormalCapturing:
@@ -169,22 +169,22 @@ namespace wisdom
                 }
                 break;
 
-            case MoveCategory::SpecialEnPassant:
+            case MoveCategory::EnPassant:
                 {
                     Coord taken_pawn_coord = en_passant_taken_pawn_coord (src, dst);
                     this->remove (opponent, taken_pawn_coord, make_piece (opponent, Piece::Pawn));
                 }
                 break;
 
-            case MoveCategory::SpecialCastling:
+            case MoveCategory::Castling:
                 {
                     int8_t rook_src_row = castling_row_from_color (who);
                     auto rook_src_col = gsl::narrow_cast<int8_t> (
-                        is_castling_move_on_king_side (move)
+                        move.is_castling_on_kingside ()
                             ? King_Rook_Column : Queen_Rook_Column
                     );
                     auto rook_dst_col = gsl::narrow_cast<int8_t> (
-                        is_castling_move_on_king_side (move)
+                        move.is_castling_on_kingside ()
                             ? Kingside_Castled_Rook_Column : Queenside_Castled_Rook_Column
                     );
 
@@ -201,8 +201,7 @@ namespace wisdom
                 throw Error { "Invalid move type." };
         }
 
-        ColoredPiece dst_piece = is_promoting_move (move) ?
-                                 move_get_promoted_piece (move) : piece;
+        ColoredPiece dst_piece = move.is_promoting () ? move.get_promoted_piece () : piece;
 
         this->add (who, dst, dst_piece);
     }

--- a/engine/src/threats.hpp
+++ b/engine/src/threats.hpp
@@ -10,10 +10,11 @@ namespace wisdom
 {
     struct InlineThreats
     {
-        struct ThreatStatus
+        enum class ThreatStatus
         {
-            bool blocked;
-            bool threatened;
+            None = 0,
+            Blocked,
+            Threatened,
         };
 
         const Board& my_board;
@@ -66,8 +67,9 @@ namespace wisdom
 
             // If the check is blocked, revert to the king position itself
             // for the calculation to avoid any branching.
-            result.threatened = has_threatening_piece;
-            result.blocked = type != Piece::None;
+            result = has_threatening_piece ? ThreatStatus::Threatened :
+                type != Piece::None ? ThreatStatus::Blocked :
+                                    ThreatStatus::None;
 
             return result;
         }
@@ -78,22 +80,18 @@ namespace wisdom
             for (auto new_col = next_column (my_king_col, +1); new_col <= Last_Column; new_col++)
             {
                 auto status = check_lane_threats (my_king_row, new_col);
-
-                if (status.threatened)
+                if (status == ThreatStatus::Threatened)
                     return true;
-
-                if (status.blocked)
+                else if (status == ThreatStatus::Blocked)
                     break;
             }
 
             for (auto new_col = next_column (my_king_col, -1); new_col >= First_Column; new_col--)
             {
                 auto status = check_lane_threats (my_king_row, new_col);
-
-                if (status.threatened)
+                if (status == ThreatStatus::Threatened)
                     return true;
-
-                if (status.blocked)
+                else if (status == ThreatStatus::Blocked)
                     break;
             }
 
@@ -106,22 +104,18 @@ namespace wisdom
             for (auto new_row = next_row (my_king_row, +1); new_row <= Last_Row; new_row++)
             {
                 auto status = check_lane_threats (new_row, my_king_col);
-
-                if (status.threatened)
+                if (status == ThreatStatus::Threatened)
                     return true;
-
-                if (status.blocked)
+                else if (status == ThreatStatus::Blocked)
                     break;
             }
 
             for (auto new_row = next_row (my_king_row, -1); new_row >= First_Row; new_row--)
             {
                 auto status = check_lane_threats (new_row, my_king_col);
-
-                if (status.threatened)
+                if (status == ThreatStatus::Threatened)
                     return true;
-
-                if (status.blocked)
+                else if (status == ThreatStatus::Blocked)
                     break;
             }
 
@@ -310,7 +304,7 @@ namespace wisdom
         constexpr auto check_diagonal_threats (int target_row, int target_col)
             -> ThreatStatus
         {
-            ThreatStatus result {};
+            ThreatStatus result = ThreatStatus::None;
 
             ColoredPiece piece = my_board.piece_at (target_row, target_col);
             auto type = piece_type (piece);
@@ -326,8 +320,9 @@ namespace wisdom
 
             // If the check is blocked, revert to the king position itself
             // for the calculation to avoid any branching.
-            result.threatened = has_threatening_piece;
-            result.blocked = type != Piece::None;
+            result = has_threatening_piece ? ThreatStatus::Threatened :
+                                           type != Piece::None ? ThreatStatus::Blocked :
+                                    ThreatStatus::None;
 
             return result;
         }
@@ -366,11 +361,9 @@ namespace wisdom
                 }
 
                 auto status = check_diagonal_threats (new_row, new_col);
-
-                if (status.threatened)
+                if (status == ThreatStatus::Threatened)
                     return true;
-
-                if (status.blocked)
+                else if (status == ThreatStatus::Blocked)
                     break;
             }
 

--- a/engine/src/threats.hpp
+++ b/engine/src/threats.hpp
@@ -235,10 +235,10 @@ namespace wisdom
 
             int left_attack_exists
                 = (is_valid_row (target_row) && is_valid_column (left_col)
-                   && my_board.piece_at (target_row, left_col) == make_piece (my_opponent, Piece::Pawn));
+                   && my_board.piece_at (target_row, left_col) == ColoredPiece::make (my_opponent, Piece::Pawn));
             int right_attack_exists
                 = (is_valid_row (target_row) && is_valid_column (right_col)
-                   && my_board.piece_at (target_row, right_col) == make_piece (my_opponent, Piece::Pawn));
+                   && my_board.piece_at (target_row, right_col) == ColoredPiece::make (my_opponent, Piece::Pawn));
 
             return left_attack_exists | right_attack_exists;
         }
@@ -253,7 +253,7 @@ namespace wisdom
         {
             int middle_col = next_column<int> (starting_col, +1);
             bool middle_attack_exists = false;
-            ColoredPiece opponent_king = make_piece (my_opponent, Piece::King);
+            ColoredPiece opponent_king = ColoredPiece::make (my_opponent, Piece::King);
 
             bool left_attack_exists = (
                 is_valid_row (target_row) && is_valid_column (starting_col)

--- a/engine/test/board_code_test.cpp
+++ b/engine/test/board_code_test.cpp
@@ -22,7 +22,7 @@ TEST_CASE( "board code")
         REQUIRE( num_zeroes == initial_str.size () );
 
         Coord a8 = coord_parse ("a8");
-        ColoredPiece black_pawn = make_piece (Color::Black, Piece::Pawn);
+        ColoredPiece black_pawn = ColoredPiece::make (Color::Black, Piece::Pawn);
         code.add_piece (a8, black_pawn);
 
         REQUIRE( code != initial );
@@ -32,7 +32,7 @@ TEST_CASE( "board code")
         REQUIRE( code == initial );
 
         Coord h1 = coord_parse ("h1");
-        ColoredPiece white_king = make_piece (Color::White, Piece::King);
+        ColoredPiece white_king = ColoredPiece::make (Color::White, Piece::King);
         code.add_piece (h1, white_king);
 
         std::string result = code.to_string ();

--- a/engine/test/board_code_test.cpp
+++ b/engine/test/board_code_test.cpp
@@ -137,8 +137,8 @@ TEST_CASE( "board code")
         REQUIRE (initial.count_ones () > 0);
 
         Move promote_castle_move = move_parse ("b7xa8 (Q)", Color::Black);
-        REQUIRE( is_promoting_move (promote_castle_move) );
-        REQUIRE( is_normal_capturing_move (promote_castle_move) );
+        REQUIRE(promote_castle_move.is_promoting () );
+        REQUIRE( promote_castle_move.is_normal_capturing () );
 
         code.apply_move (brd, promote_castle_move);
         REQUIRE( initial != code);

--- a/engine/test/board_test.cpp
+++ b/engine/test/board_test.cpp
@@ -25,9 +25,9 @@ TEST_CASE( "find_first_coord_with_piece()" )
 
     SUBCASE( "Returns the first position if there is only one position with the combo" )
     {
-        auto white_king = make_piece (Color::White, Piece::King);
-        auto black_king = make_piece (Color::Black, Piece::King);
-        auto black_pawn = make_piece (Color::Black, Piece::Pawn);
+        auto white_king = ColoredPiece::make (Color::White, Piece::King);
+        auto black_king = ColoredPiece::make (Color::Black, Piece::King);
+        auto black_pawn = ColoredPiece::make (Color::Black, Piece::Pawn);
         auto white_king_pos = board.find_first_coord_with_piece (white_king);
         auto black_king_pos = board.find_first_coord_with_piece (black_king);
         auto black_pawn_pos = board.find_first_coord_with_piece (black_pawn);
@@ -43,7 +43,7 @@ TEST_CASE( "find_first_coord_with_piece()" )
 
     SUBCASE( "Returns the first position if there are multiple positions with the same combo" )
     {
-        auto white_pawn = make_piece (Color::White, Piece::Pawn);
+        auto white_pawn = ColoredPiece::make (Color::White, Piece::Pawn);
         auto white_pawn_pos = board.find_first_coord_with_piece (white_pawn);
         auto expected_white_pawn_pos = coord_parse ("a3");
         CHECK( *white_pawn_pos == expected_white_pawn_pos );
@@ -51,7 +51,7 @@ TEST_CASE( "find_first_coord_with_piece()" )
 
     SUBCASE( "Returns nullopt if no piece is found" )
     {
-        auto white_queen = make_piece (Color::White, Piece::Queen);
+        auto white_queen = ColoredPiece::make (Color::White, Piece::Queen);
         auto white_queen_pos = board.find_first_coord_with_piece (white_queen);
         CHECK( !white_queen_pos.has_value () );
     }

--- a/engine/test/castle_test.cpp
+++ b/engine/test/castle_test.cpp
@@ -55,7 +55,7 @@ TEST_CASE("Castling state is modified and restored for rooks")
     Board board { builder };
 
     board.set_current_turn (Color::Black);
-    Move mv = Move::make_default (0, 0, 0, 1);
+    Move mv = Move::make (0, 0, 0, 1);
 
     CHECK( board.able_to_castle (Color::Black, Castle_Queenside) );
     CHECK( board.able_to_castle (Color::Black, Castle_Kingside) );
@@ -89,7 +89,7 @@ TEST_CASE("Castling state is modified and restored for kings")
     builder.add_row_of_same_color (7, Color::White, back_rank);
     Board board { builder };
     board.set_current_turn (Color::Black);
-    Move mv = Move::make_default (0, 4, 0, 3);
+    Move mv = Move::make (0, 4, 0, 3);
 
     CHECK( board.able_to_castle (Color::Black, Castle_Queenside) );
     CHECK( board.able_to_castle (Color::Black, Castle_Kingside) );

--- a/engine/test/castle_test.cpp
+++ b/engine/test/castle_test.cpp
@@ -55,7 +55,7 @@ TEST_CASE("Castling state is modified and restored for rooks")
     Board board { builder };
 
     board.set_current_turn (Color::Black);
-    Move mv = make_regular_move (0, 0, 0, 1);
+    Move mv = Move::make_default (0, 0, 0, 1);
 
     CHECK( board.able_to_castle (Color::Black, Castle_Queenside) );
     CHECK( board.able_to_castle (Color::Black, Castle_Kingside) );
@@ -89,7 +89,7 @@ TEST_CASE("Castling state is modified and restored for kings")
     builder.add_row_of_same_color (7, Color::White, back_rank);
     Board board { builder };
     board.set_current_turn (Color::Black);
-    Move mv = make_regular_move (0, 4, 0, 3);
+    Move mv = Move::make_default (0, 4, 0, 3);
 
     CHECK( board.able_to_castle (Color::Black, Castle_Queenside) );
     CHECK( board.able_to_castle (Color::Black, Castle_Kingside) );
@@ -123,7 +123,7 @@ TEST_CASE("Castling state is modified and restored for castling queenside")
     builder.add_row_of_same_color (7, Color::White, back_rank);
     Board board { builder };
     board.set_current_turn (Color::Black);
-    Move mv = make_special_castling_move (0, 4, 0, 2);
+    Move mv = Move::make_castling (0, 4, 0, 2);
 
     CHECK( board.able_to_castle (Color::Black, Castle_Queenside) );
     CHECK( board.able_to_castle (Color::Black, Castle_Kingside) );
@@ -172,7 +172,7 @@ TEST_CASE("Castling state is modified and restored for castling kingside")
     builder.add_row_of_same_color (0, Color::Black, back_rank);
     builder.add_row_of_same_color (7, Color::White, back_rank);
     Board board { builder };
-    Move mv = make_special_castling_move (7, 4, 7, 6);
+    Move mv = Move::make_castling (7, 4, 7, 6);
 
     CHECK( board.able_to_castle (Color::White, Castle_Queenside) );
     CHECK( board.able_to_castle (Color::White, Castle_Kingside) );
@@ -226,7 +226,7 @@ TEST_CASE("Opponent's castling state is modified when his rook is taken")
 
     auto board = Board { builder };
     
-    Move mv = make_normal_capturing_move (1, 1, 0, 0);
+    Move mv = Move::make_normal_capturing (1, 1, 0, 0);
 
     CHECK( board.able_to_castle (Color::White, Castle_Queenside) );
     CHECK( board.able_to_castle (Color::White, Castle_Kingside) );
@@ -280,7 +280,7 @@ TEST_CASE("Castling state is updated when rook captures a piece")
 
     auto board = Board { builder };
 
-    Move mv = make_normal_capturing_move (0, 0, 1, 0);
+    Move mv = Move::make_normal_capturing (0, 0, 1, 0);
 
     CHECK( board.able_to_castle (Color::White, Castle_Queenside) );
     CHECK( board.able_to_castle (Color::White, Castle_Kingside) );
@@ -346,7 +346,7 @@ TEST_CASE("Opponent's castling state is modified when his rook is taken (failure
     builder.set_current_turn (Color::Black);
 
     auto board = Board { builder };
-    Move mv = make_normal_capturing_move (0, 0, 0, 1);
+    Move mv = Move::make_normal_capturing (0, 0, 0, 1);
 
     CHECK( board.able_to_castle (Color::White, Castle_Queenside) );
     CHECK( board.able_to_castle (Color::White, Castle_Kingside) );
@@ -411,7 +411,7 @@ TEST_CASE("Castling state is modified when rook takes a piece on same column (sc
 
     auto board = Board { builder };
 
-    Move mv = make_normal_capturing_move (7, 0, 6, 0);
+    Move mv = Move::make_normal_capturing (7, 0, 6, 0);
 
     CHECK( board.able_to_castle (Color::White, Castle_Queenside) );
     CHECK( board.able_to_castle (Color::White, Castle_Kingside) );

--- a/engine/test/en_passant_test.cpp
+++ b/engine/test/en_passant_test.cpp
@@ -54,25 +54,26 @@ TEST_CASE( "en passant" )
         REQUIRE( !is_en_passant_vulnerable (first_undo_state, Color::Black) );
         REQUIRE( !is_en_passant_vulnerable (first_undo_state, Color::White) );
 
+        auto is_en_passant_move = [](Move move) { return move.is_en_passant (); };
         MoveList move_list = move_generator.generate_all_potential_moves (board, Color::White);
         auto maybe_en_passant_move = std::find_if (
-                move_list.begin (), move_list.end (), is_special_en_passant_move);
+                move_list.begin (), move_list.end (), is_en_passant_move);
 
         REQUIRE( maybe_en_passant_move != move_list.end () );
         auto en_passant_move = *maybe_en_passant_move;
 
         // Check move types:
-        REQUIRE( is_special_en_passant_move (en_passant_move) );
+        REQUIRE(en_passant_move.is_en_passant () );
 
         // Check position:
-        REQUIRE( Row (move_src (en_passant_move)) == 3 );
-        REQUIRE( Column (move_src (en_passant_move)) == 4 );
-        REQUIRE( Row (move_dst (en_passant_move)) == 2 );
-        REQUIRE( Column (move_dst (en_passant_move)) == 5 );
+        REQUIRE( Row (en_passant_move.get_src ()) == 3 );
+        REQUIRE( Column (en_passant_move.get_src ()) == 4 );
+        REQUIRE( Row (en_passant_move.get_dst ()) == 2 );
+        REQUIRE( Column (en_passant_move.get_dst ()) == 5 );
 
         UndoMove en_passant_undo_state = board.make_move (Color::White, en_passant_move);
 
-        REQUIRE( en_passant_undo_state.category == MoveCategory::SpecialEnPassant);
+        REQUIRE( en_passant_undo_state.category == MoveCategory::EnPassant);
         REQUIRE( is_en_passant_vulnerable (en_passant_undo_state, Color::Black) );
         REQUIRE( !is_en_passant_vulnerable (en_passant_undo_state, Color::White) );
 
@@ -119,24 +120,25 @@ TEST_CASE( "en passant" )
         REQUIRE( !is_en_passant_vulnerable (first_undo_state, Color::White) );
 
         MoveList move_list = move_generator.generate_all_potential_moves (board, Color::White);
+        auto is_en_passant_move = [](Move move) { return move.is_en_passant (); };
         auto maybe_en_passant_move = std::find_if (
-                move_list.begin(), move_list.end (), is_special_en_passant_move);
+                move_list.begin(), move_list.end (), is_en_passant_move);
 
         REQUIRE( maybe_en_passant_move != move_list.end () );
         auto en_passant_move = *maybe_en_passant_move;
 
         // Check move types:
-        REQUIRE( is_special_en_passant_move (en_passant_move) );
+        REQUIRE(en_passant_move.is_en_passant () );
 
         // Check position:
-        REQUIRE( Row (move_src (en_passant_move)) == 3 );
-        REQUIRE( Column (move_src (en_passant_move)) == 4 );
-        REQUIRE( Row (move_dst (en_passant_move)) == 2 );
-        REQUIRE( Column (move_dst (en_passant_move)) == 3 );
+        REQUIRE( Row (en_passant_move.get_src ()) == 3 );
+        REQUIRE( Column (en_passant_move.get_src ()) == 4 );
+        REQUIRE( Row (en_passant_move.get_dst ()) == 2 );
+        REQUIRE( Column (en_passant_move.get_dst ()) == 3 );
 
         UndoMove en_passant_undo_state = board.make_move (Color::White, en_passant_move);
 
-        REQUIRE( en_passant_undo_state.category == MoveCategory::SpecialEnPassant);
+        REQUIRE( en_passant_undo_state.category == MoveCategory::EnPassant);
         REQUIRE( is_en_passant_vulnerable (en_passant_undo_state, Color::Black) );
         REQUIRE( !is_en_passant_vulnerable (en_passant_undo_state, Color::White) );
 

--- a/engine/test/en_passant_test.cpp
+++ b/engine/test/en_passant_test.cpp
@@ -54,10 +54,9 @@ TEST_CASE( "en passant" )
         REQUIRE( !is_en_passant_vulnerable (first_undo_state, Color::Black) );
         REQUIRE( !is_en_passant_vulnerable (first_undo_state, Color::White) );
 
-        auto is_en_passant_move = [](Move move) { return move.is_en_passant (); };
         MoveList move_list = move_generator.generate_all_potential_moves (board, Color::White);
         auto maybe_en_passant_move = std::find_if (
-                move_list.begin (), move_list.end (), is_en_passant_move);
+                move_list.begin (), move_list.end (), std::mem_fn (&Move::is_en_passant));
 
         REQUIRE( maybe_en_passant_move != move_list.end () );
         auto en_passant_move = *maybe_en_passant_move;
@@ -120,9 +119,8 @@ TEST_CASE( "en passant" )
         REQUIRE( !is_en_passant_vulnerable (first_undo_state, Color::White) );
 
         MoveList move_list = move_generator.generate_all_potential_moves (board, Color::White);
-        auto is_en_passant_move = [](Move move) { return move.is_en_passant (); };
         auto maybe_en_passant_move = std::find_if (
-                move_list.begin(), move_list.end (), is_en_passant_move);
+                move_list.begin(), move_list.end (), std::mem_fn (&Move::is_en_passant));
 
         REQUIRE( maybe_en_passant_move != move_list.end () );
         auto en_passant_move = *maybe_en_passant_move;

--- a/engine/test/material_test.cpp
+++ b/engine/test/material_test.cpp
@@ -20,7 +20,7 @@ TEST_CASE( "Overall score" )
             {
                 Material material;
 
-                material.add (make_piece (color, piece_type));
+                material.add (ColoredPiece::make (color, piece_type));
 
                 CHECK( material.overall_score(color) > 0 );
             }
@@ -35,8 +35,8 @@ TEST_CASE( "Overall score" )
         {
             for (auto color : colors)
             {
-                material.add (make_piece (color, piece_type));
-                material.remove (make_piece (color, piece_type));
+                material.add (ColoredPiece::make (color, piece_type));
+                material.remove (ColoredPiece::make (color, piece_type));
 
                 CHECK( material.overall_score(color) == 0 );
             }

--- a/engine/test/move_list_test.cpp
+++ b/engine/test/move_list_test.cpp
@@ -74,7 +74,7 @@ TEST_CASE( "Appending a move" )
 
 TEST_CASE( "Moving uncached list" )
 {
-    MoveListAllocator allocator;
+    auto allocator = MoveListAllocator::make_unique();
 
     SUBCASE( "moving uncached into cached" )
     {
@@ -83,7 +83,7 @@ TEST_CASE( "Moving uncached list" )
         uncached_list.push_back (move_parse ("e4 d4"));
         uncached_list.push_back (move_parse ("d2 d1"));
 
-        MoveList cached { &allocator };
+        MoveList cached { allocator.get () };
 
         REQUIRE( cached.allocator () != nullptr );
         cached = std::move (uncached_list);
@@ -105,7 +105,7 @@ TEST_CASE( "Moving uncached list" )
         uncached_list.push_back (move_parse ("e4 d4"));
         uncached_list.push_back (move_parse ("d2 d1"));
 
-        MoveList cached { &allocator };
+        MoveList cached { allocator.get () };
 
         cached.push_back (move_parse ("e3 d3"));
         cached.push_back (move_parse ("d3 d1"));
@@ -126,7 +126,7 @@ TEST_CASE( "Moving uncached list" )
 
 TEST_CASE( "Swapping lists" )
 {
-    MoveListAllocator allocator;
+    auto allocator = MoveListAllocator::make_unique ();
 
     SUBCASE( "Swapping two simple lists" )
     {
@@ -144,8 +144,7 @@ TEST_CASE( "Swapping lists" )
 
     SUBCASE( "Swapping two move lists with different allocators" )
     {
-        MoveListAllocator allocator;
-        MoveList first { &allocator };
+        MoveList first { allocator.get () };
         MoveList second = { Color::Black, { "d7 d5", "f1 c4" } };
 
         first.push_back (move_parse ("e2 d4", Color::White));

--- a/engine/test/move_parse_test.cpp
+++ b/engine/test/move_parse_test.cpp
@@ -17,8 +17,8 @@ TEST_CASE( "move_parse" )
     SUBCASE( "color matters in move_parse" )
     {
         Move castle = move_parse ("o-o", Color::Black);
-        CHECK( Row (move_src (castle)) == 0 );
-        CHECK( Row (move_dst (castle)) == 0 );
+        CHECK( Row (castle.get_src ()) == 0 );
+        CHECK( Row (castle.get_dst ()) == 0 );
         CHECK( move_equals (castle, move_parse ("o-o", Color::Black)) );
     }
 

--- a/engine/test/move_test.cpp
+++ b/engine/test/move_test.cpp
@@ -243,3 +243,46 @@ TEST_CASE("Mapping coordinates to moves")
         CHECK( *result == expected );
     }
 }
+
+TEST_CASE( "Packing and unpacking a size" )
+{
+    SUBCASE( "Less than 128")
+    {
+        size_t capacity = 72;
+
+        Move packed_move = make_move_with_packed_capacity (capacity);
+        size_t result = unpack_capacity_from_move (packed_move);
+
+        REQUIRE( result == capacity );
+    }
+
+    SUBCASE( "More than 128" )
+    {
+        size_t capacity = 240;
+
+        Move packed_move = make_move_with_packed_capacity (capacity);
+        size_t result = unpack_capacity_from_move (packed_move);
+
+        REQUIRE( result == capacity );
+    }
+
+    SUBCASE( "More than 32768" )
+    {
+        size_t capacity = 71528;
+
+        Move packed_move = make_move_with_packed_capacity (capacity);
+        size_t result = unpack_capacity_from_move (packed_move);
+
+        REQUIRE( result == capacity );
+    }
+
+    SUBCASE( "Serialize maximum" )
+    {
+        size_t capacity = 0x0fffFFFF;
+
+        Move packed_move = make_move_with_packed_capacity (capacity);
+        size_t result = unpack_capacity_from_move (packed_move);
+
+        REQUIRE( result == capacity );
+    }
+}

--- a/engine/test/move_test.cpp
+++ b/engine/test/move_test.cpp
@@ -278,7 +278,7 @@ TEST_CASE( "Packing and unpacking a size" )
 
     SUBCASE( "Serialize maximum" )
     {
-        size_t capacity = 0x0fffFFFF;
+        size_t capacity = Max_Packed_Capacity_In_Move;
 
         Move packed_move = Move::make_as_packed_capacity (capacity);
         size_t result = packed_move.to_unpacked_capacity ();

--- a/engine/test/move_test.cpp
+++ b/engine/test/move_test.cpp
@@ -37,7 +37,7 @@ TEST_CASE( "Parsing a promoting move" )
     Coord src = coord_parse("d7");
     Coord dst = coord_parse("d8");
     Move expected = Move::make (src, dst);
-    expected = expected.with_promotion (make_piece (Color::White, Piece::Bishop));
+    expected = expected.with_promotion (ColoredPiece::make (Color::White, Piece::Bishop));
     REQUIRE( promoting == expected );
 }
 

--- a/engine/test/move_test.cpp
+++ b/engine/test/move_test.cpp
@@ -15,6 +15,13 @@ TEST_CASE( "Parsing a move" )
     REQUIRE(make_regular_move (coord_parse ("e2"), coord_parse ("e4")) == with_spaces );
 }
 
+TEST_CASE( "Packing source and destination coordinates" )
+{
+    Move a7xc8 = move_parse ("a7xc8", Color::White);
+    CHECK( move_dst (a7xc8) == coord_parse ("c8") );
+    CHECK( move_src (a7xc8) == coord_parse ("a7") );
+}
+
 TEST_CASE( "Parsing an en-passant move" )
 {
     Move en_passant = move_parse ("   e4d5 ep   ", Color::White);

--- a/engine/test/move_test.cpp
+++ b/engine/test/move_test.cpp
@@ -12,14 +12,14 @@ using namespace wisdom;
 TEST_CASE( "Parsing a move" )
 {
     Move with_spaces = move_parse ("   e2e4", Color::White);
-    REQUIRE(make_regular_move (coord_parse ("e2"), coord_parse ("e4")) == with_spaces );
+    REQUIRE(Move::make_default (coord_parse ("e2"), coord_parse ("e4")) == with_spaces );
 }
 
 TEST_CASE( "Packing source and destination coordinates" )
 {
     Move a7xc8 = move_parse ("a7xc8", Color::White);
-    CHECK( move_dst (a7xc8) == coord_parse ("c8") );
-    CHECK( move_src (a7xc8) == coord_parse ("a7") );
+    CHECK( a7xc8.get_dst () == coord_parse ("c8") );
+    CHECK( a7xc8.get_src () == coord_parse ("a7") );
 }
 
 TEST_CASE( "Parsing an en-passant move" )
@@ -27,7 +27,7 @@ TEST_CASE( "Parsing an en-passant move" )
     Move en_passant = move_parse ("   e4d5 ep   ", Color::White);
     Coord src = coord_parse("e4");
     Coord dst = coord_parse("d5");
-    Move expected = make_special_en_passant_move (Row (src), Column (src), Row (dst), Column (dst));
+    Move expected = Move::make_en_passant (Row (src), Column (src), Row (dst), Column (dst));
     REQUIRE( en_passant == expected );
 }
 
@@ -36,8 +36,8 @@ TEST_CASE( "Parsing a promoting move" )
     Move promoting = move_parse ("   d7d8 (B) ", Color::White);
     Coord src = coord_parse("d7");
     Coord dst = coord_parse("d8");
-    Move expected = make_regular_move (src, dst);
-    expected = copy_move_with_promotion (expected, make_piece (Color::White, Piece::Bishop));
+    Move expected = Move::make_default (src, dst);
+    expected = expected.with_promotion (make_piece (Color::White, Piece::Bishop));
     REQUIRE( promoting == expected );
 }
 
@@ -46,7 +46,7 @@ TEST_CASE( "Parsing a castling move" )
     Move castling = move_parse ("   o-o-o ", Color::Black);
     Coord src = coord_parse("e8");
     Coord dst = coord_parse("c8");
-    Move expected = make_special_castling_move (Row (src), Column (src), Row (dst), Column (dst));
+    Move expected = Move::make_castling (Row (src), Column (src), Row (dst), Column (dst));
 
     REQUIRE( castling == expected );
 }
@@ -250,8 +250,8 @@ TEST_CASE( "Packing and unpacking a size" )
     {
         size_t capacity = 72;
 
-        Move packed_move = make_move_with_packed_capacity (capacity);
-        size_t result = unpack_capacity_from_move (packed_move);
+        Move packed_move = Move::make_as_packed_capacity (capacity);
+        size_t result = packed_move.to_unpacked_capacity ();
 
         REQUIRE( result == capacity );
     }
@@ -260,8 +260,8 @@ TEST_CASE( "Packing and unpacking a size" )
     {
         size_t capacity = 240;
 
-        Move packed_move = make_move_with_packed_capacity (capacity);
-        size_t result = unpack_capacity_from_move (packed_move);
+        Move packed_move = Move::make_as_packed_capacity (capacity);
+        size_t result = packed_move.to_unpacked_capacity ();
 
         REQUIRE( result == capacity );
     }
@@ -270,8 +270,8 @@ TEST_CASE( "Packing and unpacking a size" )
     {
         size_t capacity = 71528;
 
-        Move packed_move = make_move_with_packed_capacity (capacity);
-        size_t result = unpack_capacity_from_move (packed_move);
+        Move packed_move = Move::make_as_packed_capacity (capacity);
+        size_t result = packed_move.to_unpacked_capacity ();
 
         REQUIRE( result == capacity );
     }
@@ -280,8 +280,8 @@ TEST_CASE( "Packing and unpacking a size" )
     {
         size_t capacity = 0x0fffFFFF;
 
-        Move packed_move = make_move_with_packed_capacity (capacity);
-        size_t result = unpack_capacity_from_move (packed_move);
+        Move packed_move = Move::make_as_packed_capacity (capacity);
+        size_t result = packed_move.to_unpacked_capacity ();
 
         REQUIRE( result == capacity );
     }

--- a/engine/test/move_test.cpp
+++ b/engine/test/move_test.cpp
@@ -12,7 +12,7 @@ using namespace wisdom;
 TEST_CASE( "Parsing a move" )
 {
     Move with_spaces = move_parse ("   e2e4", Color::White);
-    REQUIRE(Move::make_default (coord_parse ("e2"), coord_parse ("e4")) == with_spaces );
+    REQUIRE( Move::make (coord_parse ("e2"), coord_parse ("e4")) == with_spaces );
 }
 
 TEST_CASE( "Packing source and destination coordinates" )
@@ -36,7 +36,7 @@ TEST_CASE( "Parsing a promoting move" )
     Move promoting = move_parse ("   d7d8 (B) ", Color::White);
     Coord src = coord_parse("d7");
     Coord dst = coord_parse("d8");
-    Move expected = Move::make_default (src, dst);
+    Move expected = Move::make (src, dst);
     expected = expected.with_promotion (make_piece (Color::White, Piece::Bishop));
     REQUIRE( promoting == expected );
 }

--- a/engine/test/perft.cpp
+++ b/engine/test/perft.cpp
@@ -34,10 +34,10 @@ namespace wisdom
             if (depth == target_depth)
             {
                 counters.nodes++;
-                if (is_any_capturing_move (move))
+                if (move.is_any_capturing ())
                     counters.captures++;
 
-                if (is_special_en_passant_move (move))
+                if (move.is_en_passant ())
                     counters.en_passants++;
             }
 
@@ -67,7 +67,7 @@ namespace wisdom
         auto dst_piece = board.piece_at (dst);
         assert (piece_color (src_piece) == who);
 
-        Move result = wisdom::make_regular_move (src, dst);
+        Move result = wisdom::Move::make_default (src, dst);
 
         // 1. castling is represented by two space king moves
         if (wisdom::piece_type (src_piece) == Piece::King)
@@ -77,7 +77,7 @@ namespace wisdom
             if (castling_row == Row (src) && castling_row == Row (dst)
                 && std::abs (Column (src) - Column (dst)))
             {
-                result = make_special_castling_move (src, dst);
+                result = Move::make_castling (src, dst);
             }
         }
 
@@ -87,17 +87,17 @@ namespace wisdom
             if (Row (src) != Row (dst) && Column (src) != Column (dst)
                 && dst_piece == Piece_And_Color_None)
             {
-                result = make_special_en_passant_move (src, dst);
+                result = Move::make_en_passant (src, dst);
             }
         }
 
         // 3. captures denoted without x
         if (dst_piece != Piece_And_Color_None)
-            result = wisdom::copy_move_with_capture (result);
+            result = result.with_capture ();
 
         // 4. Promotions are not in parenthesis
         if (promoted != Piece_And_Color_None)
-            result = wisdom::copy_move_with_promotion (result, promoted);
+            result = result.with_promotion (promoted);
 
         return result;
     }
@@ -125,31 +125,31 @@ namespace wisdom
 
     auto wisdom::perft::to_perft_move (const Move& move, Color who) -> string
     {
-        if (is_special_castling_move (move))
+        if (move.is_castling ())
         {
             auto row = who == Color::White ? Last_Row : First_Row;
             auto src_col = King_Column;
-            auto dst_col = is_castling_move_on_king_side (move) ? Kingside_Castled_King_Column
-                                                                : Queenside_Castled_King_Column;
+            auto dst_col = move.is_castling_on_kingside () ? Kingside_Castled_King_Column
+                                                           : Queenside_Castled_King_Column;
 
-            Move normal = wisdom::make_regular_move (row, src_col, row, dst_col);
-            return wisdom::to_string (move_src (normal)) + wisdom::to_string (move_dst (normal));
+            Move normal = wisdom::Move::make_default (row, src_col, row, dst_col);
+            return wisdom::to_string (normal.get_src ()) + wisdom::to_string (normal.get_dst ());
         }
 
-        if (is_special_en_passant_move (move))
+        if (move.is_en_passant ())
         {
-            return wisdom::to_string (move_src (move)) + wisdom::to_string (move_dst (move));
+            return wisdom::to_string (move.get_src ()) + wisdom::to_string (move.get_dst ());
         }
 
-        if (is_promoting_move (move))
+        if (move.is_promoting ())
         {
-            auto promoted = move_get_promoted_piece (move);
+            auto promoted = move.get_promoted_piece ();
 
-            return wisdom::to_string (move_src (move)) + wisdom::to_string (move_dst (move))
+            return wisdom::to_string (move.get_src ()) + wisdom::to_string (move.get_dst ())
                 + wisdom::piece_char (promoted);
         }
 
-        return wisdom::to_string (move_src (move)) + wisdom::to_string (move_dst (move));
+        return wisdom::to_string (move.get_src ()) + wisdom::to_string (move.get_dst ());
     }
 
     auto wisdom::perft::perft_results (const Board& board, Color active_player, int depth,

--- a/engine/test/perft.cpp
+++ b/engine/test/perft.cpp
@@ -67,7 +67,7 @@ namespace wisdom
         auto dst_piece = board.piece_at (dst);
         assert (piece_color (src_piece) == who);
 
-        Move result = wisdom::Move::make_default (src, dst);
+        Move result = wisdom::Move::make (src, dst);
 
         // 1. castling is represented by two space king moves
         if (wisdom::piece_type (src_piece) == Piece::King)
@@ -132,7 +132,7 @@ namespace wisdom
             auto dst_col = move.is_castling_on_kingside () ? Kingside_Castled_King_Column
                                                            : Queenside_Castled_King_Column;
 
-            Move normal = wisdom::Move::make_default (row, src_col, row, dst_col);
+            Move normal = wisdom::Move::make (row, src_col, row, dst_col);
             return wisdom::to_string (normal.get_src ()) + wisdom::to_string (normal.get_dst ());
         }
 

--- a/engine/test/perft.cpp
+++ b/engine/test/perft.cpp
@@ -60,7 +60,7 @@ namespace wisdom
         if (move_str.size () == 5)
         {
             auto promoted_type = piece_from_char (move_str[4]);
-            promoted = make_piece (who, promoted_type);
+            promoted = ColoredPiece::make (who, promoted_type);
         }
 
         auto src_piece = board.piece_at (src);

--- a/engine/test/piece_test.cpp
+++ b/engine/test/piece_test.cpp
@@ -18,14 +18,14 @@ TEST_CASE( "A piece can be converted" )
 
     for (auto color : colors) {
         for (auto piece : pieces) {
-            ColoredPiece combined = make_piece (color, piece);
+            ColoredPiece combined = ColoredPiece::make (color, piece);
             INFO( to_string(piece_type(combined)) );
             INFO( to_string(piece) );
             CHECK( piece_type(combined) == piece );
             CHECK( piece_color(combined) == color );
         }
     }
-    CHECK( Piece_And_Color_None == make_piece (Color::None, Piece::None) );
+    CHECK( Piece_And_Color_None == ColoredPiece::make (Color::None, Piece::None) );
     CHECK( piece_type (Piece_And_Color_None) == Piece::None );
     CHECK( piece_color (Piece_And_Color_None) == Color::None );
 }

--- a/engine/test/position_test.cpp
+++ b/engine/test/position_test.cpp
@@ -71,7 +71,7 @@ TEST_CASE( "En passant updates position overall_score correctly")
     int initial_score_black = board.get_position ().overall_score (Color::Black);
 
     Move e5xd5 = move_parse ("e5d6 ep", Color::White);
-    CHECK(is_special_en_passant_move (e5xd5) );
+    CHECK(e5xd5.is_en_passant () );
 
     UndoMove undo_state = board.make_move (Color::White, e5xd5);
     board.take_back (Color::White, e5xd5, undo_state);
@@ -99,7 +99,7 @@ TEST_CASE( "Castling updates position overall_score correctly")
     for (auto castling_move_in : castling_moves)
     {
         Move castling_move = move_parse (castling_move_in, Color::White);
-        CHECK(is_special_castling_move (castling_move));
+        CHECK( castling_move.is_castling ());
 
         UndoMove undo_state = board.make_move (Color::White, castling_move);
         board.take_back (Color::White, castling_move, undo_state);
@@ -126,7 +126,7 @@ TEST_CASE( "Promoting move updates position overall_score correctly")
     for (auto promoting_move_in : promoting_moves)
     {
         Move castling_move = move_parse (promoting_move_in, Color::White);
-        CHECK(is_promoting_move (castling_move));
+        CHECK(castling_move.is_promoting () );
 
         UndoMove undo_state = board.make_move (Color::White, castling_move);
         board.take_back (Color::White, castling_move, undo_state);

--- a/engine/test/search_test.cpp
+++ b/engine/test/search_test.cpp
@@ -191,7 +191,7 @@ TEST_CASE ("Bishop is not sacrificed scenario 1")
     // assert the bishop has moved:
     INFO ("Info:", to_string (*result.move));
     REQUIRE (game.get_board ().piece_at (coord_parse ("b4"))
-             != make_piece (Color::Black, Piece::Bishop));
+             != ColoredPiece::make (Color::Black, Piece::Bishop));
 }
 
 TEST_CASE ("Bishop is not sacrificed scenario 2 (as white)")
@@ -211,7 +211,7 @@ TEST_CASE ("Bishop is not sacrificed scenario 2 (as white)")
     // assert the bishop has moved:
     INFO ("Info:", to_string (*result.move));
     auto a3_piece = game.get_board ().piece_at (coord_parse ("a3"));
-    bool bishop_sac = a3_piece != make_piece (Color::White, Piece::Bishop);
+    bool bishop_sac = a3_piece != ColoredPiece::make (Color::White, Piece::Bishop);
     bool is_in_check = is_king_threatened (game.get_board (), Color::Black,
                                            game.get_board ().get_king_position (Color::Black));
     bool bishop_sac_or_is_in_check = bishop_sac || is_in_check;
@@ -236,7 +236,7 @@ TEST_CASE ("Advanced pawn should be captured")
     // assert the pawn at d6 has been taken:
     INFO ("Info:", to_string (*result.move));
     auto board = game.get_board ();
-    REQUIRE (board.piece_at (coord_parse ("d6")) != make_piece (Color::White, Piece::Pawn));
+    REQUIRE (board.piece_at (coord_parse ("d6")) != ColoredPiece::make (Color::White, Piece::Pawn));
 }
 
 TEST_CASE( "Checkmate is preferred to stalemate" )

--- a/qt-qml-gui/gamemodel.cpp
+++ b/qt-qml-gui/gamemodel.cpp
@@ -241,7 +241,7 @@ bool GameModel::needsPawnPromotion(int srcRow, int srcColumn, int dstRow, int ds
     if (!optionalMove.has_value()) {
         return false;
     }
-    return is_promoting_move(*optionalMove);
+    return optionalMove->is_promoting();
 }
 
 void GameModel::applicationExiting()

--- a/qt-qml-gui/piecesmodel.cpp
+++ b/qt-qml-gui/piecesmodel.cpp
@@ -11,12 +11,12 @@ namespace {
 
     constexpr auto whitePiece(Piece piece) -> int8_t
     {
-        return to_int8(make_piece(Color::White, piece));
+        return to_int8(ColoredPiece::make(Color::White, piece));
     }
 
     constexpr auto blackPiece(Piece piece) -> int8_t
     {
-        return to_int8(make_piece(Color::Black, piece));
+        return to_int8(ColoredPiece::make(Color::Black, piece));
     }
 
     auto initPieceMap() -> QHash<int8_t, QString>
@@ -59,8 +59,8 @@ void PiecesModel::newGame(gsl::not_null<const ChessGame*> game)
         endRemoveRows();
     }
 
-    for (int row = 0; row < 8; row++) {
-        for (int column = 0; column < 8; column++) {
+    for (int row = 0; row < wisdom::Num_Rows; row++) {
+        for (int column = 0; column < wisdom::Num_Columns; column++) {
             auto piece = board.piece_at(row, column);
             if (piece != Piece_And_Color_None) {
                 PieceInfo newPiece {

--- a/qt-qml-gui/piecesmodel.cpp
+++ b/qt-qml-gui/piecesmodel.cpp
@@ -114,13 +114,13 @@ QHash<int, QByteArray> PiecesModel::roleNames() const
 
 void PiecesModel::playerMoved(Move selectedMove, wisdom::Color who)
 {
-    Coord src = move_src(selectedMove);
-    Coord dst = move_dst(selectedMove);
+    Coord src = selectedMove.get_src();
+    Coord dst = selectedMove.get_dst();
 
-    int srcRow = Row(src);
-    int srcColumn = Column(src);
-    int dstRow = Row(dst);
-    int dstColumn = Column(dst);
+    int srcRow = Row<int>(src);
+    int srcColumn = Column<int>(src);
+    int dstRow = Row<int>(dst);
+    int dstColumn = Column<int>(dst);
 
     auto count = myPieces.count();
     for (int i = 0; i < count; i++) {
@@ -138,8 +138,8 @@ void PiecesModel::playerMoved(Move selectedMove, wisdom::Color who)
             QVector<int> rolesChanged { RowRole, ColumnRole };
             QModelIndex changedIndex = index(i, 0);
 
-            if (is_promoting_move(selectedMove)) {
-                auto promotedPiece = move_get_promoted_piece(selectedMove);
+            if (selectedMove.is_promoting()) {
+                auto promotedPiece = selectedMove.get_promoted_piece();
                 auto newImagePath = myPieceToImagePath[to_int8(promotedPiece)];
                 pieceModel.pieceImage = newImagePath;
                 rolesChanged.append( PieceImageRole );
@@ -147,11 +147,11 @@ void PiecesModel::playerMoved(Move selectedMove, wisdom::Color who)
 
             emit dataChanged(changedIndex, changedIndex, rolesChanged);
         }
-        if (is_special_castling_move(selectedMove)) {
+        if (selectedMove.is_castling()) {
             auto sourceRookRow = who == wisdom::Color::White ? 7 : 0;
-            auto sourceRookColumn = is_castling_move_on_king_side(selectedMove)
+            auto sourceRookColumn = selectedMove.is_castling_on_kingside()
                     ? King_Rook_Column : Queen_Rook_Column;
-            auto dstRookColumn = is_castling_move_on_king_side(selectedMove)
+            auto dstRookColumn = selectedMove.is_castling_on_kingside()
                     ? Kingside_Castled_Rook_Column : Queenside_Castled_Rook_Column;
 
             if (pieceModel.row == sourceRookRow && pieceModel.column == sourceRookColumn) {
@@ -164,7 +164,7 @@ void PiecesModel::playerMoved(Move selectedMove, wisdom::Color who)
                 });
             }
         }
-        if (is_special_en_passant_move(selectedMove)) {
+        if (selectedMove.is_en_passant()) {
             int direction = pawn_direction(who) * -1;
             int enPassantPawnRow = dstRow + direction;
             int enPassantPawnCol = dstColumn;

--- a/qt-qml-gui/piecesmodel.cpp
+++ b/qt-qml-gui/piecesmodel.cpp
@@ -78,7 +78,13 @@ void PiecesModel::newGame(gsl::not_null<const ChessGame*> game)
 
 int PiecesModel::rowCount(const QModelIndex& index) const
 {
-    return gsl::narrow<int>(myPieces.count());
+    if (index.isValid()) {
+        // At some index - no child rows.
+        return 0;
+    } else {
+        // At the root: equal to the number of top-level rows.
+        return gsl::narrow<int>(myPieces.count());
+    }
 }
 
 QVariant PiecesModel::data(const QModelIndex& index, int role) const
@@ -88,16 +94,16 @@ QVariant PiecesModel::data(const QModelIndex& index, int role) const
     }
 
     int dataRow = index.row();
-
     auto pieceInfo = myPieces.at(dataRow);
-    if (role == RowRole) {
+    switch (role) {
+    case RowRole:
         return pieceInfo.row;
-    } else if (role == ColumnRole) {
+    case ColumnRole:
         return pieceInfo.column;
-    } else if (role == PieceImageRole) {
+    case PieceImageRole:
         return pieceInfo.pieceImage;
-    } else {
-        return QVariant{};
+    default:
+        return QVariant {};
     }
 }
 


### PR DESCRIPTION
Store the size inside the move list memory block itself as the first entry, and also use `std::unique_ptr<Move[]>` instead of `Move*` and `make_unique` instead of `realloc`. 

The `realloc` likely doesn't gain too much performance because we're already caching the move lists with the `MoveListAllocator`.

This also then adds static and instance methods to  the `Move` class and moves those away from free functions. 

Also, add a `make_unique` static method to `MoveListAllocator` and make the `MoveListAllocator` constructor private, to ensure it isn't allocated on the stack by accident since it needs to maintain a consistent address.