### PR TITLE
Parallelize bit assignment in board code

### DIFF
--- a/engine/src/board_code.cpp
+++ b/engine/src/board_code.cpp
@@ -136,13 +136,16 @@ namespace wisdom
 
     auto BoardCode::countOnes() const -> std::size_t
     {
-        string str = my_pieces.to_string();
+        string str = asString();
         return std::count (str.begin(), str.end(), '1');
     }
 
     auto operator<< (std::ostream& os, const BoardCode& code) -> std::ostream&
     {
-        os << "{ bits: " << code.my_pieces << ", ancillary: " << code.my_ancillary << " }";
+        os << "{ bits: ";
+        for (const auto& bits : code.my_pieces)
+            os << bits;
+        os << ", metadata: " << code.my_metadata << " }";
         return os;
     }
 

--- a/engine/src/board_code.hpp
+++ b/engine/src/board_code.hpp
@@ -29,17 +29,19 @@ namespace wisdom
 
         using PiecesBitset = array<bitset<Bits_Per_Pieces_Element>, Num_Pieces_Elements>;
 
-        static constexpr int Metadata_Total_Bits = 16;
+        static constexpr int Total_Metadata_Bits = 16;
 
-        using MetadataBitset = bitset<Metadata_Total_Bits>;
+        using MetadataBitset = bitset<Total_Metadata_Bits>;
 
         static std::hash<MetadataBitset> metadata_hash_fn;
 
-        enum PieceBitPositions : std::size_t {
-            PIECE_MASK = 0b1111ULL,
+        enum PieceBits : std::size_t
+        {
+            PIECE_MASK = 0b1111,
         };
 
-        enum AncillaryBitPositions : std::size_t {
+        enum MetadataBits : std::size_t
+        {
             CURRENT_TURN_BIT = 0,
             EN_PASSANT_WHITE_TARGET = 1,
             EN_PASSANT_BLACK_TARGET = 5,
@@ -165,7 +167,7 @@ namespace wisdom
         {
             std::string result;
 
-            result.reserve (Total_Piece_Bits + Metadata_Total_Bits);
+            result.reserve (Total_Piece_Bits + Total_Metadata_Bits);
 
             // Most-significant bits first (big-endian):
             for (auto i = my_pieces.crbegin(); i != my_pieces.crend(); i++)

--- a/engine/src/coord.hpp
+++ b/engine/src/coord.hpp
@@ -52,14 +52,15 @@ namespace wisdom
     constexpr Coord No_En_Passant_Coord = First_Coord;
 
     // Return square index from zero to sixty-three, with a8 as 0 and h1 as 63.
-    [[nodiscard]] constexpr auto coordIndex (Coord coord) -> int
+    template <typename IntegerType = int>
+    [[nodiscard]] constexpr auto coordIndex (Coord coord) -> IntegerType
     {
         return coord.row_and_col;
     }
 
     // Return square index from zero to sixty-three, with a8 as 0 and h1 as 63.
-    template <typename IntegerType = int8_t>
-    [[nodiscard]] constexpr auto coordIndex (IntegerType row, IntegerType col) -> int
+    template <typename IntegerType = int8_t, typename ResultType = int>
+    [[nodiscard]] constexpr auto coordIndex (IntegerType row, IntegerType col) -> ResultType
     {
         static_assert (std::is_integral_v<IntegerType>);
         Coord coord = makeCoord (row, col);

--- a/engine/src/global.hpp
+++ b/engine/src/global.hpp
@@ -45,6 +45,7 @@ namespace wisdom
     using std::make_shared;
     using std::nullopt;
     using std::array;
+    using std::bitset;
     using std::pair;
 
     template <typename T>

--- a/engine/test/board_code_test.cpp
+++ b/engine/test/board_code_test.cpp
@@ -44,7 +44,7 @@ TEST_CASE( "board code")
         CHECK( result == "0000" );
     }
 
-    SUBCASE("Capturing moves are applied and undone correctly")
+    SUBCASE( "Capturing moves are applied and undone correctly" )
     {
         BoardBuilder builder;
 
@@ -64,7 +64,7 @@ TEST_CASE( "board code")
         REQUIRE( initial != code );
     }
 
-    SUBCASE("Promoting moves are applied and undone correctly")
+    SUBCASE( "Promoting moves are applied and undone correctly" )
     {
         BoardBuilder builder;
 
@@ -85,7 +85,7 @@ TEST_CASE( "board code")
         REQUIRE( initial != code );
     }
 
-    SUBCASE("Castling moves are applied and undone correctly")
+    SUBCASE( "Castling moves are applied and undone correctly" )
     {
         BoardBuilder builder;
 
@@ -131,8 +131,7 @@ TEST_CASE( "board code")
     }
 }
 
-
-TEST_CASE( "Board code stores ancilliary state" )
+TEST_CASE( "Board code stores metadata" )
 {
     SUBCASE( "Board code stores en passant state for Black" )
     {
@@ -153,8 +152,8 @@ TEST_CASE( "Board code stores ancilliary state" )
 
         auto en_passant_target = with_state_code.enPassantTarget (Color::Black);
         auto expected_coord = coordParse ("d6");
-        auto ancilliary = with_state_code.getAncillaryBits();
-        INFO(ancilliary);
+        auto metadata = with_state_code.getMetadataBits();
+        INFO( metadata );
         INFO( wisdom::asString (en_passant_target) );
         CHECK( en_passant_target == expected_coord );
 
@@ -182,11 +181,11 @@ TEST_CASE( "Board code stores ancilliary state" )
         auto en_passant_target = with_state_code.enPassantTarget (Color::White);
 
         auto expected_coord = coordParse ("e3");
-        auto ancilliary = with_state_code.getAncillaryBits();
+        auto metadata = with_state_code.getMetadataBits();
         CHECK( en_passant_target == expected_coord );
 
         auto opponent_target = with_state_code.enPassantTarget (Color::Black);
-        INFO(ancilliary);
+        INFO( metadata );
         INFO( wisdom::asString (opponent_target) );
 
         CHECK( opponent_target == No_En_Passant_Coord );
@@ -194,11 +193,39 @@ TEST_CASE( "Board code stores ancilliary state" )
 
     SUBCASE( "Board code stores castle state" )
     {
+        BoardCode board_code = BoardCode::fromDefaultPosition();
 
+        auto initial_white_state = board_code.castleState (Color::White);
+        auto initial_black_state = board_code.castleState (Color::Black);
+
+        CHECK( initial_white_state == CastlingEligible::EitherSideEligible);
+        CHECK( initial_black_state == CastlingEligible::EitherSideEligible);
+
+        board_code.setCastleState (Color::White, CastlingEligible::BothSidesIneligible);
+        auto white_state = board_code.castleState (Color::White);
+        auto black_state = board_code.castleState (Color::Black);
+
+        CHECK( white_state == CastlingEligible::BothSidesIneligible );
+        CHECK( black_state == CastlingEligible::EitherSideEligible );
+
+        board_code.setCastleState (Color::White, CastlingEligible::KingsideIneligible);
+        board_code.setCastleState (Color::Black, CastlingEligible::QueensideIneligible);
+        white_state = board_code.castleState (Color::White);
+        black_state = board_code.castleState (Color::Black);
+
+        CHECK( white_state == CastlingEligible::KingsideIneligible );
+        CHECK( black_state == CastlingEligible::QueensideIneligible );
     }
 
     SUBCASE( "Board code stores whose turn it is" )
     {
+        BoardCode board_code = BoardCode::fromDefaultPosition();
 
+        auto current_turn = board_code.currentTurn();
+        CHECK( current_turn == Color::White );
+
+        board_code.setCurrentTurn (Color::Black);
+        auto next_turn = board_code.currentTurn();
+        CHECK( next_turn == Color::Black );
     }
 }

--- a/engine/test/board_code_test.cpp
+++ b/engine/test/board_code_test.cpp
@@ -12,7 +12,7 @@ using namespace wisdom;
 
 TEST_CASE( "board code")
 {
-    SUBCASE( "Board code is able to be set" )
+    SUBCASE( "Board code is able to be set for an empty board" )
     {
         BoardCode code = BoardCode::fromEmptyBoard();
         BoardCode initial = BoardCode::fromEmptyBoard();
@@ -42,6 +42,15 @@ TEST_CASE( "board code")
         code.removePiece (h1);
         result = code.asString().substr (0, 4);
         CHECK( result == "0000" );
+    }
+
+    SUBCASE( "Board code sets up a default board" )
+    {
+        BoardCode code = BoardCode::fromDefaultPosition();
+
+        auto num_ones = code.countOnes ();
+
+        CHECK( num_ones >= 32 ); // each piece must have at least one bit.
     }
 
     SUBCASE( "Capturing moves are applied and undone correctly" )


### PR DESCRIPTION
Parallelize the bit assignment by using array of bitsets that will fit within a 64-bit word, so that a loop across the bitset can be eliminated.

This adds some more loops to slower paths, like converting the board code to a string.