### PR TITLE
Cleanup search

### DIFF
--- a/engine/src/board_code.cpp
+++ b/engine/src/board_code.cpp
@@ -144,10 +144,7 @@ namespace wisdom
 
     auto operator<< (std::ostream& os, const BoardCode& code) -> std::ostream&
     {
-        os << "{ bits: ";
-        for (const auto& bits : code.my_pieces)
-            os << bits;
-        os << ", metadata: " << code.my_metadata << " }";
+        os << code.asString();
         return os;
     }
 

--- a/engine/src/search.cpp
+++ b/engine/src/search.cpp
@@ -33,6 +33,7 @@ namespace wisdom
         int search (const Board& parent_board, Color side, int depth,
                     int alpha, int beta);
 
+        // Get the best result the search found.
         [[nodiscard]] auto getBestResult() const -> SearchResult;
 
         [[nodiscard]] auto moveTimer() const -> not_null<const MoveTimer*>
@@ -44,13 +45,12 @@ namespace wisdom
         Board my_original_board;
         History my_history;
         not_null<observer_ptr<const Logger>> my_output;
+        SearchResult my_current_result {};
         MoveGenerator my_generator {};
         MoveTimer my_timer;
+
         int my_total_depth;
         int my_search_depth {};
-
-        SearchResult my_current_result {};
-
         int my_nodes_visited = 0;
         int my_alpha_beta_cutoffs = 0;
         int my_total_nodes_visited = 0;

--- a/engine/src/search.hpp
+++ b/engine/src/search.hpp
@@ -16,16 +16,10 @@ namespace wisdom
 
     struct SearchResult
     {
-        optional<Move> move;
-        int score;
-        int depth;
-        bool timed_out;
-
-        static SearchResult from_initial() noexcept
-        {
-            SearchResult result { nullopt, -Initial_Alpha, 0, false };
-            return result;
-        }
+        int score = -Initial_Alpha;
+        int depth { 0 };
+        optional<Move> move { nullopt };
+        bool timed_out { false };
     };
 
     class IterativeSearch

--- a/engine/test/board_code_test.cpp
+++ b/engine/test/board_code_test.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <sstream>
 
 #include "board_code.hpp"
 #include "coord.hpp"
@@ -138,6 +139,40 @@ TEST_CASE( "board code")
 
         code.applyMove (brd, promote_castle_move);
         REQUIRE( initial != code );
+    }
+}
+
+TEST_CASE( "Board code can be converted" )
+{
+    SUBCASE( "to a string" )
+    {
+        std::stringstream stream;
+        BoardCode code = BoardCode::fromEmptyBoard();
+
+        code.addPiece(
+            coordParse("h1"),
+            ColoredPiece::make(Color::White, Piece::King)
+        );
+
+        auto result = code.asString().substr(0, 4);
+
+        CHECK( result == "0110" );
+    }
+
+    SUBCASE( "to an ostream" )
+    {
+        std::stringstream stream;
+        BoardCode code = BoardCode::fromEmptyBoard();
+
+        code.addPiece(
+            coordParse("h1"),
+            ColoredPiece::make(Color::White, Piece::King)
+        );
+
+        stream << code;
+        auto result = stream.str().substr(0, 4);
+
+        CHECK( result == "0110" );
     }
 }
 


### PR DESCRIPTION
- Make the `search()` recursive method return the score instead of storing it on the object, to make the search process easier to 
understand.
- Make the `BoardCode` converstion to a string consistent with the representation sent to a `std::ostream`