### PR TITLE
Rename some functions on MoveList

### DIFF
--- a/engine/src/check.cpp
+++ b/engine/src/check.cpp
@@ -17,7 +17,7 @@ namespace wisdom
 
         MoveList legal_moves = generator.generateLegalMoves (board, who);
 
-        return legal_moves.empty();
+        return legal_moves.isEmpty();
     }
 
     auto isLegalPositionAfterMove (const Board& board, Color who, Move mv) -> bool
@@ -59,6 +59,6 @@ namespace wisdom
         auto coord = board.getKingPosition (who);
         auto legal_moves = generator.generateLegalMoves (board, who);
 
-        return legal_moves.empty() && !isKingThreatened (board, who, coord);
+        return legal_moves.isEmpty() && !isKingThreatened (board, who, coord);
     }
 }

--- a/engine/src/generate.cpp
+++ b/engine/src/generate.cpp
@@ -71,7 +71,7 @@ namespace wisdom
                     if (my_knight_moves[index] == nullptr) {
                         my_knight_moves[index] = make_unique<MoveList> (my_move_list_allocator.get());
                     }
-                    my_knight_moves[index]->pushBack (knight_move);
+                    my_knight_moves[index]->append (knight_move);
                 }
             }
         }
@@ -148,7 +148,7 @@ namespace wisdom
             return;
 
         auto transformed_move = transformMove (dst_piece, move);
-        moves.pushBack (transformed_move);
+        moves.append (transformed_move);
     }
 
     void MoveGeneration::none()
@@ -404,7 +404,7 @@ namespace wisdom
             Board new_board = board.withMove (who, move);
 
             if (isLegalPositionAfterMove (new_board, who, move))
-                non_checks.pushBack (move);
+                non_checks.append (move);
         }
 
         return non_checks;

--- a/engine/src/move_list.cpp
+++ b/engine/src/move_list.cpp
@@ -12,7 +12,7 @@ namespace wisdom
     {
         for (auto&& it : list)
         {
-            pushBack (moveParse (it, color));
+            append (moveParse (it, color));
             color = colorInvert (color);
         }
     }

--- a/engine/src/move_list.hpp
+++ b/engine/src/move_list.hpp
@@ -114,15 +114,25 @@ namespace wisdom
         MoveList (MoveList&& other) noexcept = default;
         MoveList& operator= (MoveList&& other) noexcept = default;
 
-        void pushBack (Move move) noexcept
+        void push_back (Move move) noexcept
+        {
+            append (move);
+        }
+
+        void pop_back() noexcept
+        {
+            removeLast();
+        }
+
+        void append (Move move) noexcept
         {
             MoveListAllocator::moveListAppend (my_moves_list, my_size, move);
             my_size++;
         }
 
-        void popBack() noexcept
+        void removeLast() noexcept
         {
-            assert (my_size > 0);
+            Expects (my_size > 0);
             my_size--;
         }
 
@@ -162,7 +172,12 @@ namespace wisdom
         }
         void end() && = delete;
 
-        [[nodiscard]] bool empty() const noexcept
+        [[nodiscard]] auto empty() const noexcept -> bool
+        {
+            return isEmpty();
+        }
+
+        [[nodiscard]] auto isEmpty() const noexcept -> bool
         {
             return my_size == 0;
         }

--- a/engine/test/move_list_test.cpp
+++ b/engine/test/move_list_test.cpp
@@ -63,8 +63,8 @@ TEST_CASE( "Appending a move" )
 {
     MoveList list = MoveList::uncached();
 
-    list.pushBack (moveParse ("e4 e5"));
-    list.pushBack (moveParse ("d7 d5"));
+    list.append (moveParse ("e4 e5"));
+    list.append (moveParse ("d7 d5"));
 
     REQUIRE( list.size() == 2 );
 }
@@ -77,8 +77,8 @@ TEST_CASE( "Moving uncached list" )
     {
         MoveList uncached_list = MoveList::uncached();
 
-        uncached_list.pushBack (moveParse ("e4 d4"));
-        uncached_list.pushBack (moveParse ("d2 d1"));
+        uncached_list.append (moveParse ("e4 d4"));
+        uncached_list.append (moveParse ("d2 d1"));
 
         MoveList cached { allocator.get() };
 
@@ -99,13 +99,13 @@ TEST_CASE( "Moving uncached list" )
     {
         MoveList uncached_list = MoveList::uncached();
 
-        uncached_list.pushBack (moveParse ("e4 d4"));
-        uncached_list.pushBack (moveParse ("d2 d1"));
+        uncached_list.append (moveParse ("e4 d4"));
+        uncached_list.append (moveParse ("d2 d1"));
 
         MoveList cached { allocator.get() };
 
-        cached.pushBack (moveParse ("e3 d3"));
-        cached.pushBack (moveParse ("d3 d1"));
+        cached.append (moveParse ("e3 d3"));
+        cached.append (moveParse ("d3 d1"));
 
         REQUIRE( uncached_list.allocator() == nullptr );
         uncached_list = std::move (cached);
@@ -144,8 +144,8 @@ TEST_CASE( "Swapping lists" )
         MoveList first { allocator.get() };
         MoveList second = { Color::Black, { "d7 d5", "f1 c4" } };
 
-        first.pushBack (moveParse ("e2 d4", Color::White));
-        first.pushBack (moveParse ("a8 a1", Color::Black));
+        first.append (moveParse ("e2 d4", Color::White));
+        first.append (moveParse ("a8 a1", Color::Black));
 
         std::swap (first, second);
 

--- a/engine/test/perft.cpp
+++ b/engine/test/perft.cpp
@@ -111,7 +111,7 @@ namespace wisdom
             auto move = convertMove (board_copy, who, move_str);
             board_copy = board_copy.withMove (who, move);
             who = colorInvert (who);
-            result.pushBack (move);
+            result.append (move);
         }
 
         return result;


### PR DESCRIPTION
- Rename some functions on move list to use `append` / `removeLast` / `isEmpty` instead of `pushBack` / `popBack` / `empty`.
- Add `push_back` / `pop_back` / `empty` for some compatibility with STL