### PR TITLE
Fix static constexpr to inline constexpr

### DIFF
--- a/engine/src/board_code.hpp
+++ b/engine/src/board_code.hpp
@@ -32,9 +32,9 @@ namespace wisdom
         return code_array;
     }
 
-    static constexpr BoardCodeArray Hash_Code_Table = initializeBoardCodes();
+    inline constexpr BoardCodeArray Hash_Code_Table = initializeBoardCodes();
 
-    static constexpr int Total_Metadata_Bits = 16;
+    inline constexpr int Total_Metadata_Bits = 16;
 
     [[nodiscard]] constexpr auto boardCodeHash (Coord coord, ColoredPiece piece) -> std::uint64_t
     {
@@ -230,7 +230,7 @@ namespace std
     template<>
     struct hash<wisdom::BoardCode>
     {
-        auto operator() (const wisdom::BoardCode& code) const -> std::size_t
+        auto operator() (const wisdom::BoardCode& code) const noexcept -> std::size_t
         {
             return code.hashCode();
         }

--- a/engine/src/global.hpp
+++ b/engine/src/global.hpp
@@ -66,56 +66,56 @@ namespace wisdom
         WeightPawn = 100,
     };
 
-    static constexpr int Num_Players = 2;
+    inline constexpr int Num_Players = 2;
 
-    static constexpr int Num_Rows = 8;
-    static constexpr int Num_Columns = 8;
-    static constexpr int Num_Squares = Num_Rows * Num_Columns;
+    inline constexpr int Num_Rows = 8;
+    inline constexpr int Num_Columns = 8;
+    inline constexpr int Num_Squares = Num_Rows * Num_Columns;
 
-    static constexpr int First_Row = 0;
-    static constexpr int First_Column = 0;
+    inline constexpr int First_Row = 0;
+    inline constexpr int First_Column = 0;
 
-    static constexpr int Last_Row = 7;
-    static constexpr int Last_Column = 7;
+    inline constexpr int Last_Row = 7;
+    inline constexpr int Last_Column = 7;
 
-    static constexpr int King_Column = 4;
-    static constexpr int King_Rook_Column = 7;
-    static constexpr int Queen_Rook_Column = 0;
+    inline constexpr int King_Column = 4;
+    inline constexpr int King_Rook_Column = 7;
+    inline constexpr int Queen_Rook_Column = 0;
 
     // Where the color is vulnerable to en passant:
-    static constexpr int White_En_Passant_Row = 5;
-    static constexpr int Black_En_Passant_Row = 2;
+    inline constexpr int White_En_Passant_Row = 5;
+    inline constexpr int Black_En_Passant_Row = 2;
 
-    static constexpr int Kingside_Castled_King_Column = 6;
-    static constexpr int Queenside_Castled_King_Column = 2;
-    static constexpr int Kingside_Castled_Rook_Column = 5;
-    static constexpr int Queenside_Castled_Rook_Column = 3;
+    inline constexpr int Kingside_Castled_King_Column = 6;
+    inline constexpr int Queenside_Castled_King_Column = 2;
+    inline constexpr int Kingside_Castled_Rook_Column = 5;
+    inline constexpr int Queenside_Castled_Rook_Column = 3;
 
     // Scale factor for the material and position scale. Used for balancing material
     // and position scores together.
-    static constexpr int Material_Score_Scale = 2;
-    static constexpr int Position_Score_Scale = 9;
+    inline constexpr int Material_Score_Scale = 2;
+    inline constexpr int Position_Score_Scale = 9;
 
     // Initial Alpha value for alpha-beta search.
-    static constexpr int Initial_Alpha = std::numeric_limits<int>::max() / 3;
+    inline constexpr int Initial_Alpha = std::numeric_limits<int>::max() / 3;
 
     // Infinite score - regular scores can never be this high.
     // Checkmates are scored above this, depending on how far
     // away from the current position they are.
-    static constexpr int Max_Non_Checkmate_Score
+    inline constexpr int Max_Non_Checkmate_Score
         = Num_Squares * WeightQueen *
         std::max (Material_Score_Scale, Position_Score_Scale);
     static_assert (Max_Non_Checkmate_Score > 100'000 && Max_Non_Checkmate_Score < Initial_Alpha);
 
     // Default absolute max depth searched.
-    static constexpr int Default_Max_Depth = 16;
+    inline constexpr int Default_Max_Depth = 16;
 
     // Default max time spent searching.
-    static constexpr int Default_Max_Search_Seconds = 5;
+    inline constexpr int Default_Max_Search_Seconds = 5;
 
     // Minimum amount behind the computer must feel in order to
     // accept a draw offer.
-    static constexpr int Min_Draw_Score = -500;
+    inline constexpr int Min_Draw_Score = -500;
 
     // Errors in this application.
     class Error : public std::exception

--- a/engine/src/move.hpp
+++ b/engine/src/move.hpp
@@ -29,8 +29,8 @@ namespace wisdom
 {
     using CastlingEligibility = type_safe::flag_set<wisdom::CastlingIneligible>;
 
-    static constexpr CastlingEligibility Either_Side_Eligible = type_safe::noflag;
-    static constexpr CastlingEligibility Neither_Side_Eligible
+    inline constexpr CastlingEligibility Either_Side_Eligible = type_safe::noflag;
+    inline constexpr CastlingEligibility Neither_Side_Eligible
         = CastlingIneligible::Kingside | CastlingIneligible::Queenside;
 
     inline constexpr auto makeCastlingEligibilityFromInt (unsigned int flags) -> CastlingEligibility
@@ -73,7 +73,7 @@ namespace wisdom
 
     class Board;
 
-    static constexpr size_t Max_Packed_Capacity_In_Move = 0x001FFFFFL; // 21 bit max
+    inline constexpr size_t Max_Packed_Capacity_In_Move = 0x001FFFFFL; // 21 bit max
 
     enum class MoveCategory : int8_t
     {

--- a/engine/src/piece.hpp
+++ b/engine/src/piece.hpp
@@ -24,7 +24,7 @@ namespace wisdom
         King
     };
 
-    static constexpr std::size_t Num_Piece_Types = static_cast<std::size_t> (Piece::King) + 1;
+    inline constexpr std::size_t Num_Piece_Types = static_cast<std::size_t> (Piece::King) + 1;
 
     enum class Color : int8_t
     {
@@ -33,8 +33,8 @@ namespace wisdom
         Black = 2,
     };
 
-    static constexpr int Color_Index_White = 0;
-    static constexpr int Color_Index_Black = 1;
+    inline constexpr int Color_Index_White = 0;
+    inline constexpr int Color_Index_Black = 1;
 
     using ColorIndex = int8_t;
 
@@ -109,11 +109,11 @@ namespace wisdom
     }
 
     // 3 bits for type of piece
-    static constexpr int8_t Piece_Type_Mask = 0x08-1;
+    inline constexpr int8_t Piece_Type_Mask = 0x08-1;
 
     // 2 bits for color
-    static constexpr int8_t Piece_Color_Mask = 0x18;
-    static constexpr int8_t Piece_Color_Shift = 3;
+    inline constexpr int8_t Piece_Color_Mask = 0x18;
+    inline constexpr int8_t Piece_Color_Shift = 3;
 
     struct ColoredPiece
     {
@@ -164,7 +164,7 @@ namespace wisdom
 
     // Order here is significant - it means computer will prefer the piece at the top
     // all else being equal, such as if the promoted piece cannot be saved from capture.
-    static constexpr Piece All_Promotable_Piece_Types[] = {
+    inline constexpr Piece All_Promotable_Piece_Types[] = {
             Piece::Queen,
             Piece::Rook,
             Piece::Bishop,
@@ -181,7 +181,7 @@ namespace wisdom
         return piece.color();
     }
 
-    static constexpr ColoredPiece Piece_And_Color_None = ColoredPiece::make (
+    inline constexpr ColoredPiece Piece_And_Color_None = ColoredPiece::make (
         Color::None,
         Piece::None
     );


### PR DESCRIPTION
In header files, static constexpr will lead to duplication of variables because the variables will get duplicated in each translation unit.

Use `inline constexpr` instead to reduce binary size and memory used.