### PR TITLE
Static move list

### DIFF
--- a/engine/src/generate.cpp
+++ b/engine/src/generate.cpp
@@ -522,7 +522,7 @@ namespace wisdom
         MoveList result;
         MoveGeneration generation { board, result, 0, 0, who, *this };
 
-        for (auto coord : board.allCoords())
+        for (auto coord : Board::allCoords())
         {
             ColoredPiece piece = board.pieceAt (coord);
 

--- a/engine/src/generate.cpp
+++ b/engine/src/generate.cpp
@@ -67,12 +67,8 @@ namespace wisdom
                     Move knight_move = Move::make (k_row + row, k_col + col, row, col);
                     int dst_row = k_row + row;
                     int dst_col = k_col + col;
-                    auto coord = Coord::make (dst_row, dst_col);
-                    auto index = coord.index();
-                    if (my_knight_moves[index] == nullptr) {
-                        my_knight_moves[index] = make_unique<MoveList> ();
-                    }
-                    my_knight_moves[index]->append (knight_move);
+                    auto index = Coord::make (dst_row, dst_col).index();
+                    my_knight_moves[index].append (knight_move);
                 }
             }
         }
@@ -82,10 +78,10 @@ namespace wisdom
     {
         auto coord = Coord::make (row, col);
 
-        if (my_knight_moves[0] == nullptr)
+        if (my_knight_moves[0].isEmpty())
             knightMoveListInit();
 
-        return *my_knight_moves[coord.index()];
+        return my_knight_moves[coord.index()];
     }
 
     static auto isPawnUnmoved (const Board &board, int row, int col) -> bool
@@ -121,7 +117,8 @@ namespace wisdom
             piece3 = board.pieceAt (Row (src), Column (dst) - 1);
         }
 
-        return pieceType (piece1) == Piece::None && pieceType (piece2) == Piece::None && pieceType (piece3) == Piece::None;
+        return pieceType (piece1) == Piece::None && pieceType (piece2) == Piece::None
+            && pieceType (piece3) == Piece::None;
     }
 
     auto MoveGeneration::transformMove (ColoredPiece dst_piece, Move move) noexcept
@@ -174,14 +171,16 @@ namespace wisdom
 
         if (board.ableToCastle (who, CastlingIneligible::Queenside) && piece_col == King_Column)
         {
-            Move queenside_castle = Move::makeCastling (piece_row, piece_col, piece_row, piece_col - 2);
+            Move queenside_castle
+                = Move::makeCastling (piece_row, piece_col, piece_row, piece_col - 2);
             if (validCastlingMove (board, queenside_castle))
                 appendMove (queenside_castle);
         }
 
         if (board.ableToCastle (who, CastlingIneligible::Kingside) && piece_col == King_Column)
         {
-            Move kingside_castle = Move::makeCastling (piece_row, piece_col, piece_row, piece_col + 2);
+            Move kingside_castle
+                = Move::makeCastling (piece_row, piece_col, piece_row, piece_col + 2);
             if (validCastlingMove (board, kingside_castle))
                 appendMove (kingside_castle);
         }
@@ -204,7 +203,8 @@ namespace wisdom
                     break;
             }
 
-            for (col = nextColumn (piece_col, dir); isValidColumn (col); col = nextColumn (col, dir))
+            for (col = nextColumn (piece_col, dir); isValidColumn (col);
+                 col = nextColumn (col, dir))
             {
                 ColoredPiece piece = board.pieceAt (piece_row, col);
 

--- a/engine/src/generate.cpp
+++ b/engine/src/generate.cpp
@@ -70,7 +70,7 @@ namespace wisdom
                     auto coord = Coord::make (dst_row, dst_col);
                     auto index = coord.index();
                     if (my_knight_moves[index] == nullptr) {
-                        my_knight_moves[index] = make_unique<MoveList> (my_move_list_allocator.get());
+                        my_knight_moves[index] = make_unique<MoveList> ();
                     }
                     my_knight_moves[index]->append (knight_move);
                 }
@@ -397,7 +397,7 @@ namespace wisdom
 
     auto MoveGenerator::generateLegalMoves (const Board& board, Color who) const -> MoveList
     {
-        MoveList non_checks { my_move_list_allocator.get() };
+        MoveList non_checks;
 
         MoveList all_moves = generateAllPotentialMoves (board, who);
         for (auto move : all_moves)
@@ -519,7 +519,7 @@ namespace wisdom
     auto MoveGenerator::generateAllPotentialMoves (const Board& board, Color who) const
         -> MoveList
     {
-        MoveList result { my_move_list_allocator.get() };
+        MoveList result;
         MoveGeneration generation { board, result, 0, 0, who, *this };
 
         for (auto coord : board.allCoords())

--- a/engine/src/generate.hpp
+++ b/engine/src/generate.hpp
@@ -12,7 +12,7 @@ namespace wisdom
     class MoveGenerator final
     {
     private:
-        mutable array<unique_ptr<MoveList>, Num_Squares> my_knight_moves {};
+        mutable array<MoveList, Num_Squares> my_knight_moves {};
 
         void knightMoveListInit() const;
 

--- a/engine/src/generate.hpp
+++ b/engine/src/generate.hpp
@@ -12,7 +12,6 @@ namespace wisdom
     class MoveGenerator final
     {
     private:
-        mutable unique_ptr<MoveListAllocator> my_move_list_allocator = MoveListAllocator::makeUnique();
         mutable array<unique_ptr<MoveList>, Num_Squares> my_knight_moves {};
 
         void knightMoveListInit() const;

--- a/engine/src/move_list.cpp
+++ b/engine/src/move_list.cpp
@@ -1,6 +1,5 @@
 #include "move_list.hpp"
 
-#include <cstdlib>
 #include <iostream>
 
 namespace wisdom

--- a/engine/src/move_list.cpp
+++ b/engine/src/move_list.cpp
@@ -4,8 +4,6 @@
 
 namespace wisdom
 {
-    // When using an initalizer list, that is used in a context where performance
-    // isn't that important. So use the default, private, uncached constructor.
     MoveList::MoveList (Color color, std::initializer_list<czstring> list) noexcept
         : MoveList {}
     {

--- a/engine/src/move_list.hpp
+++ b/engine/src/move_list.hpp
@@ -12,8 +12,8 @@ namespace wisdom
     class MoveList // NOLINT(*-pro-type-member-init)
     {
     private:
-        array<Move, Max_Move_List_Size> my_moves;
         std::ptrdiff_t my_size = 0;
+        array<Move, Max_Move_List_Size> my_moves;
 
     public:
         MoveList() = default;

--- a/engine/src/move_list.hpp
+++ b/engine/src/move_list.hpp
@@ -26,7 +26,7 @@ namespace wisdom
             my_size = other.my_size;
         }
 
-        MoveList& operator= (const MoveList& other)
+        auto operator= (const MoveList& other) -> MoveList&
         {
             if (&other != this)
             {
@@ -98,7 +98,7 @@ namespace wisdom
             return my_size == 0;
         }
 
-        [[nodiscard]] size_t size() const noexcept
+        [[nodiscard]] auto size() const noexcept -> size_t
         {
             return my_size;
         }

--- a/engine/src/move_list.hpp
+++ b/engine/src/move_list.hpp
@@ -12,8 +12,8 @@ namespace wisdom
     class MoveList // NOLINT(*-pro-type-member-init)
     {
     private:
-        array<Move, Max_Move_List_Size> my_moves;
         std::ptrdiff_t my_size = 0;
+        array<Move, Max_Move_List_Size> my_moves;
 
     public:
         MoveList() = default;
@@ -79,7 +79,7 @@ namespace wisdom
 
         MoveList (const MoveList& other) // NOLINT(*-pro-type-member-init)
         {
-            std::copy (other.my_moves.begin(), other.my_moves.end(), my_moves.begin());
+            std::copy (other.my_moves.begin(), other.my_moves.begin() + other.my_size, begin());
             my_size = other.my_size;
         }
 
@@ -87,7 +87,7 @@ namespace wisdom
         {
             if (&other != this)
             {
-                std::copy (other.my_moves.begin(), other.my_moves.end(), my_moves.begin());
+                std::copy (other.begin(), other.my_moves.begin() + other.my_size, begin());
                 my_size = other.my_size;
             }
             return *this;

--- a/engine/src/move_list.hpp
+++ b/engine/src/move_list.hpp
@@ -36,6 +36,7 @@ namespace wisdom
 
         void append (Move move) noexcept
         {
+            Expects (my_size < Max_Move_List_Size);
             my_moves[my_size++] = move;
         }
 

--- a/engine/src/move_list.hpp
+++ b/engine/src/move_list.hpp
@@ -12,13 +12,29 @@ namespace wisdom
     class MoveList // NOLINT(*-pro-type-member-init)
     {
     private:
-        std::ptrdiff_t my_size = 0;
         array<Move, Max_Move_List_Size> my_moves;
+        std::ptrdiff_t my_size = 0;
 
     public:
         MoveList() = default;
 
         MoveList (Color color, std::initializer_list<czstring> list) noexcept;
+
+        MoveList (const MoveList& other) // NOLINT(*-pro-type-member-init)
+        {
+            std::copy (other.my_moves.begin(), other.my_moves.begin() + other.my_size, my_moves.begin());
+            my_size = other.my_size;
+        }
+
+        MoveList& operator= (const MoveList& other)
+        {
+            if (&other != this)
+            {
+                std::copy (other.my_moves.begin(), other.my_moves.begin() + other.my_size, my_moves.begin());
+                my_size = other.my_size;
+            }
+            return *this;
+        }
 
         void push_back (Move move) noexcept
         {
@@ -42,32 +58,32 @@ namespace wisdom
             my_size--;
         }
 
-        [[nodiscard]] auto begin() const& noexcept
+        [[nodiscard]] auto begin() const noexcept
         {
             return my_moves.begin();
         }
 
-        [[nodiscard]] auto end() const& noexcept
+        [[nodiscard]] auto end() const noexcept
         {
             return my_moves.begin() + my_size;
         }
 
-        [[nodiscard]] auto cbegin() const& noexcept
+        [[nodiscard]] auto cbegin() const noexcept
         {
             return my_moves.cbegin();
         }
 
-        [[nodiscard]] auto cend() const& noexcept
+        [[nodiscard]] auto cend() const noexcept
         {
             return my_moves.cbegin() + my_size;
         }
 
-        [[nodiscard]] auto begin() & noexcept
+        [[nodiscard]] auto begin() noexcept
         {
             return my_moves.begin();
         }
 
-        [[nodiscard]] auto end() & noexcept
+        [[nodiscard]] auto end() noexcept
         {
             return my_moves.begin() + my_size;
         }
@@ -75,22 +91,6 @@ namespace wisdom
         [[nodiscard]] auto empty() const noexcept -> bool
         {
             return isEmpty();
-        }
-
-        MoveList (const MoveList& other) // NOLINT(*-pro-type-member-init)
-        {
-            std::copy (other.my_moves.begin(), other.my_moves.begin() + other.my_size, begin());
-            my_size = other.my_size;
-        }
-
-        MoveList& operator= (const MoveList& other)
-        {
-            if (&other != this)
-            {
-                std::copy (other.begin(), other.my_moves.begin() + other.my_size, begin());
-                my_size = other.my_size;
-            }
-            return *this;
         }
 
         [[nodiscard]] auto isEmpty() const noexcept -> bool
@@ -121,8 +121,6 @@ namespace wisdom
             return my_moves;
         }
         void data() const&& = delete;
-
-        void ptr() const&& = delete;
     };
 
     auto asString (const MoveList& list) -> string;

--- a/engine/src/move_list.hpp
+++ b/engine/src/move_list.hpp
@@ -9,7 +9,7 @@ namespace wisdom
 {
     inline constexpr std::ptrdiff_t Max_Move_List_Size = 256 - sizeof (std::ptrdiff_t);
 
-    class MoveList
+    class MoveList // NOLINT(*-pro-type-member-init)
     {
     private:
         array<Move, Max_Move_List_Size> my_moves;
@@ -19,10 +19,6 @@ namespace wisdom
         MoveList() = default;
 
         MoveList (Color color, std::initializer_list<czstring> list) noexcept;
-
-        // Delete special copy members:
-        MoveList (const MoveList& other) = delete;
-        MoveList& operator= (const MoveList& other) = delete;
 
         void push_back (Move move) noexcept
         {
@@ -50,56 +46,49 @@ namespace wisdom
         {
             return my_moves.begin();
         }
-        void begin() const&& = delete;
 
         [[nodiscard]] auto end() const& noexcept
         {
             return my_moves.begin() + my_size;
         }
-        void end() const&& = delete;
 
         [[nodiscard]] auto cbegin() const& noexcept
         {
             return my_moves.cbegin();
         }
-        void cbegin() const&& = delete;
 
         [[nodiscard]] auto cend() const& noexcept
         {
             return my_moves.cbegin() + my_size;
         }
-        void cend() const&& = delete;
 
         [[nodiscard]] auto begin() & noexcept
         {
             return my_moves.begin();
         }
-        void begin() && = delete;
 
         [[nodiscard]] auto end() & noexcept
         {
             return my_moves.begin() + my_size;
         }
-        void end() && = delete;
 
         [[nodiscard]] auto empty() const noexcept -> bool
         {
             return isEmpty();
         }
 
-        MoveList (MoveList&& other) noexcept
+        MoveList (const MoveList& other) // NOLINT(*-pro-type-member-init)
         {
-            std::copy (other.begin(), other.end(), begin());
+            std::copy (other.my_moves.begin(), other.my_moves.end(), my_moves.begin());
             my_size = other.my_size;
-            other.my_size = 0;
         }
 
-        auto operator= (MoveList&& other) noexcept -> MoveList&
+        MoveList& operator= (const MoveList& other)
         {
-            if (&other != this) {
-                std::copy (other.begin(), other.end(), begin());
+            if (&other != this)
+            {
+                std::copy (other.my_moves.begin(), other.my_moves.end(), my_moves.begin());
                 my_size = other.my_size;
-                other.my_size = 0;
             }
             return *this;
         }

--- a/engine/test/perft.cpp
+++ b/engine/test/perft.cpp
@@ -99,7 +99,7 @@ namespace wisdom
     auto wisdom::perft::toMoveList (const wisdom::Board& board, Color who, const string& move_list)
         -> MoveList
     {
-        MoveList result = MoveList::uncached();
+        MoveList result;
 
         // Make a copy of the board for modifications:
         auto board_copy = board;

--- a/engine/test/perft.hpp
+++ b/engine/test/perft.hpp
@@ -9,14 +9,12 @@ namespace wisdom
     enum class Color : int8_t;
     struct Move;
     class MoveGenerator;
-    class MoveListAllocator;
 }
 
 namespace wisdom::perft
 {
     using std::string;
     using wisdom::MoveGenerator;
-    using wisdom::MoveListAllocator;
 
     struct MoveCounter
     {


### PR DESCRIPTION
Remove dynamic allocation from the move list.

The max move list possible is around 200 moves, that consumes 1k of memory. Just allocate it statically.