### PR TITLE
Don't install doctest files

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -13,6 +13,8 @@ CPMAddPackage(
   NAME doctest
   GITHUB_REPOSITORY doctest/doctest
   GIT_TAG v2.4.11
+  OPTIONS
+     "DOCTEST_NO_INSTALL On"
 )
 
 find_package(doctest)
@@ -27,6 +29,8 @@ else()
     message("-- wisdom-chess: precompiled headers enabled")
 endif()
 
+add_subdirectory(src)
+
 if (doctest_FOUND)
     message("-- wisdom-chess: Including tests with doctest")
     add_subdirectory(test)
@@ -35,5 +39,3 @@ else()
     set(WISDOM_CHESS_SLOW_TESTS Off)
     set(WISDOM_CHESS_FAST_TESTS Off)
 endif()
-
-add_subdirectory(src)

--- a/engine/test/CMakeLists.txt
+++ b/engine/test/CMakeLists.txt
@@ -27,6 +27,7 @@ if (WISDOM_CHESS_FAST_TESTS)
 
     target_link_libraries(fast_tests PRIVATE wisdom::chess)
     target_link_libraries(fast_tests PRIVATE doctest::doctest)
+
 endif()
 
 if (WISDOM_CHESS_SLOW_TESTS)
@@ -34,6 +35,7 @@ if (WISDOM_CHESS_SLOW_TESTS)
     add_executable(slow_tests
         search_test.cpp
         perft.cpp
+        perft.hpp
         tests.hpp
         perft_test.cpp
         move_perft_test.cpp
@@ -45,6 +47,9 @@ if (WISDOM_CHESS_SLOW_TESTS)
     
     # For perft testing:
     add_executable(perft 
-        perft_main.cpp perft.cpp)
+        perft.hpp
+        perft.cpp
+        perft_main.cpp)
     target_link_libraries(perft PRIVATE wisdom::chess)
+
 endif()

--- a/engine/test/CMakeLists.txt
+++ b/engine/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 if (WISDOM_CHESS_FAST_TESTS)
-    add_library(fast_tests_lib OBJECT
+
+    add_executable(fast_tests
         piece_test.cpp
         coord_test.cpp
         en_passant_test.cpp
@@ -20,34 +21,30 @@ if (WISDOM_CHESS_FAST_TESTS)
         str_test.cpp
         board_test.cpp
         game_test.cpp
-    )
+        test_main.cpp)
 
-    target_precompile_headers(fast_tests_lib PRIVATE PRIVATE ../src/global.hpp <doctest/doctest.h>)
+    target_precompile_headers(fast_tests PRIVATE PRIVATE ../src/global.hpp)
 
-    target_link_libraries(fast_tests_lib PUBLIC wisdom::chess)
-    target_link_libraries(fast_tests_lib PUBLIC doctest::doctest)
-
-    add_executable(fast_tests test_main.cpp)
-
-    target_link_libraries(fast_tests PRIVATE fast_tests_lib)
+    target_link_libraries(fast_tests PRIVATE wisdom::chess)
+    target_link_libraries(fast_tests PRIVATE doctest::doctest)
 endif()
 
 if (WISDOM_CHESS_SLOW_TESTS)
+
+    add_executable(slow_tests
+        search_test.cpp
+        perft.cpp
+        tests.hpp
+        perft_test.cpp
+        move_perft_test.cpp
+        test_main.cpp)
+
+    target_precompile_headers(slow_tests PRIVATE PRIVATE ../src/global.hpp)
+    target_link_libraries(slow_tests PRIVATE wisdom::chess)
+    target_link_libraries(slow_tests PRIVATE doctest::doctest)
+    
     # For perft testing:
-    add_executable(perft perft_main.cpp perft.cpp)
+    add_executable(perft 
+        perft_main.cpp perft.cpp)
     target_link_libraries(perft PRIVATE wisdom::chess)
-
-    add_library(slow_tests_lib OBJECT
-            search_test.cpp
-            perft.cpp
-            tests.hpp
-            perft_test.cpp
-            move_perft_test.cpp)
-
-    target_precompile_headers(slow_tests_lib REUSE_FROM fast_tests_lib)
-    target_link_libraries(slow_tests_lib PUBLIC wisdom::chess)
-    target_link_libraries(slow_tests_lib PUBLIC doctest::doctest)
-
-    add_executable(slow_tests test_main.cpp)
-    target_link_libraries(slow_tests PRIVATE slow_tests_lib)
 endif()


### PR DESCRIPTION
- Simplify the test build config to remove intermediate object library and pre-compiled doctest header
- Disable installing the doctest header files by passing DOCTEST_NO_INSTALL option to the doctest cmake build.