### PR TITLE
Replace Row()/Column()

### DIFF
--- a/engine/src/board.hpp
+++ b/engine/src/board.hpp
@@ -192,7 +192,7 @@ namespace wisdom
 
     constexpr auto coordColor (Coord coord) -> Color
     {
-        int parity = (Row (coord) % 2 + Column (coord) % 2) % 2;
+        int parity = (coord.row() % 2 + coord.column() % 2) % 2;
         return colorFromColorIndex (gsl::narrow_cast<int8_t> (parity));
     }
 

--- a/engine/src/board_builder.cpp
+++ b/engine/src/board_builder.cpp
@@ -27,7 +27,7 @@ namespace wisdom
 
         Coord algebraic = coordParse (coord_str);
 
-        addPiece (Row (algebraic), Column (algebraic), who, piece_type);
+        addPiece (algebraic.row(), algebraic.column(), who, piece_type);
     }
 
     auto BoardBuilder::calculateCastleStateFromPosition (Color who) const
@@ -93,7 +93,7 @@ namespace wisdom
         Coord coord = coordParse (coord_str);
 
         for (int col = 0; col < Num_Columns; col++)
-            addPiece (Row (coord), col, who, piece_type);
+            addPiece (coord.row(), col, who, piece_type);
     }
 
     void BoardBuilder::addRowOfSameColor (int row, Color who, const PieceRow& piece_types)
@@ -110,7 +110,7 @@ namespace wisdom
         Coord coord = coordParse (coord_str);
 
         for (auto col = 0; col < Num_Columns; col++)
-            addPiece (Row (coord), col, who, piece_types[col]);
+            addPiece (coord.row(), col, who, piece_types[col]);
     }
 
     void BoardBuilder::setCurrentTurn (Color who)

--- a/engine/src/board_code.hpp
+++ b/engine/src/board_code.hpp
@@ -91,14 +91,17 @@ namespace wisdom
             std::size_t target_bit_shift = color == Color::White 
                 ? EN_PASSANT_WHITE_TARGET 
                 : EN_PASSANT_BLACK_TARGET;
-            auto coord_bits = Column<std::size_t> (coord);
+            auto coord_bits = coord.column<std::size_t>();
             coord_bits |= (coord == No_En_Passant_Coord) 
                 ? 0 
                 : EN_PASSANT_PRESENT;
             coord_bits <<= target_bit_shift;
 
-            assert (coord == No_En_Passant_Coord || (
-                    Row (coord) == (color == Color::White ? White_En_Passant_Row : Black_En_Passant_Row)));
+            assert (
+                coord == No_En_Passant_Coord || (
+                    coord.row() == (color == Color::White ? White_En_Passant_Row : Black_En_Passant_Row)
+                )
+            );
 
             // clear both targets initially. There can be only one at a given time.
             auto metadata = getMetadataBits();

--- a/engine/src/check.cpp
+++ b/engine/src/check.cpp
@@ -27,14 +27,14 @@ namespace wisdom
         if (isKingThreatened (board, who, king_coord))
             return false;
 
-        auto king_row = Row (king_coord);
-        auto king_col = Column (king_coord);
+        auto king_row = king_coord.row();
+        auto king_col = king_coord.column();
 
         if (mv.isCastling())
         {
             Coord castled_pos = mv.getDst();
-            auto castled_row = Row (castled_pos);
-            auto castled_col = Column (castled_pos);
+            auto castled_row = castled_pos.row();
+            auto castled_col = castled_pos.column();
 
             assert (king_row == castled_row);
             assert (king_col == castled_col);

--- a/engine/src/coord.cpp
+++ b/engine/src/coord.cpp
@@ -22,8 +22,8 @@ namespace wisdom
     auto asString (Coord coord) -> string
     {
         string result = ""; // NOLINT(readability-redundant-string-init)
-        result += colToChar (Column (coord));
-        result += rowToChar (Row (coord));
+        result += colToChar (coord.column());
+        result += rowToChar (coord.row());
         return result;
     }
 

--- a/engine/src/coord.hpp
+++ b/engine/src/coord.hpp
@@ -23,13 +23,17 @@ namespace wisdom
         int8_t row_and_col;
 
         // Make a coordinate from an index from 0-63.
-        [[nodiscard]] static constexpr auto fromIndex (int index) -> Coord
+        [[nodiscard]] static constexpr auto 
+        fromIndex (int index) 
+            -> Coord
         {
             assert (index >= 0 && index < Num_Squares);
             return { .row_and_col = gsl::narrow_cast<int8_t> (index) };
         }
 
-        [[nodiscard]] static constexpr auto make (int row, int col) -> Coord
+        [[nodiscard]] static constexpr auto 
+        make (int row, int col) 
+            -> Coord
         {
             assert (isValidRow (row) && isValidColumn (col));
             Coord result = { .row_and_col = gsl::narrow_cast<int8_t> (row << 3 | col) };
@@ -38,20 +42,26 @@ namespace wisdom
 
         // Return square index from zero to sixty-three, with a8 as 0 and h1 as 63.
         template <typename IntegerType = int>
-        [[nodiscard]] constexpr auto index() -> IntegerType
+        [[nodiscard]] constexpr auto 
+        index() 
+            -> IntegerType
         {
             return gsl::narrow_cast<IntegerType> (row_and_col);
         }
 
         template <typename IntegerType = int8_t>
-        [[nodiscard]] constexpr auto row() -> IntegerType
+        [[nodiscard]] constexpr auto 
+        row() 
+            -> IntegerType
         {
             static_assert (std::is_integral_v<IntegerType>);
             return gsl::narrow_cast<IntegerType> (row_and_col >> 3);
         }
 
         template <typename IntegerType = int8_t>
-        [[nodiscard]] constexpr auto column() -> IntegerType
+        [[nodiscard]] constexpr auto 
+        column() 
+            -> IntegerType
         {
             static_assert (std::is_integral_v<IntegerType>);
             return gsl::narrow_cast<IntegerType> (row_and_col & 0b111);
@@ -83,13 +93,13 @@ namespace wisdom
     constexpr Coord No_En_Passant_Coord = First_Coord;
 
     template <typename IntegerType = int8_t>
-    [[nodiscard]] constexpr auto Row (Coord pos) -> IntegerType
+    [[nodiscard]] constexpr auto coordRow (Coord pos) -> IntegerType
     {
         return pos.row<IntegerType>();
     }
 
     template <typename IntegerType = int8_t>
-    [[nodiscard]] constexpr auto Column (Coord pos) -> IntegerType
+    [[nodiscard]] constexpr auto coordColumn (Coord pos) -> IntegerType
     {
         return pos.column<IntegerType>();
     }

--- a/engine/src/evaluate.cpp
+++ b/engine/src/evaluate.cpp
@@ -13,8 +13,8 @@ namespace wisdom
         auto heuristicIsCastled (const Board& board, Color who) -> bool
         {
             auto king_pos = board.getKingPosition (who);
-            auto king_column = Column<int> (king_pos);
-            auto king_row = Row<int> (king_pos);
+            auto king_column = king_pos.column<int>();
+            auto king_row = king_pos.row<int>();
 
             auto rook_piece = ColoredPiece::make (who, Piece::Rook);
 

--- a/engine/src/generate.cpp
+++ b/engine/src/generate.cpp
@@ -51,8 +51,8 @@ namespace wisdom
     {
         for (auto coord : CoordIterator {})
         {
-            int row = Row<int> (coord);
-            int col = Column<int> (coord);
+            int row = coord.row<int>();
+            int col = coord.column<int>();
 
             for (int k_row = -2; k_row <= 2; k_row++)
             {
@@ -272,7 +272,7 @@ namespace wisdom
 
         int left_column = column - 1;
         int right_column = column + 1;
-        int target_column = Column<int> (board.getEnPassantTarget (opponent));
+        int target_column = coordColumn<int> (board.getEnPassantTarget (opponent));
 
         if (left_column == target_column)
         {
@@ -416,8 +416,8 @@ namespace wisdom
 
     void MoveGeneration::generate (ColoredPiece piece, Coord coord)
     {
-        this->piece_row = Row<int> (coord);
-        this->piece_col = Column<int> (coord);
+        this->piece_row = coord.row<int>();
+        this->piece_col = coord.column<int>();
 
         switch (pieceType (piece))
         {

--- a/engine/src/generate.cpp
+++ b/engine/src/generate.cpp
@@ -109,15 +109,15 @@ namespace wisdom
         ColoredPiece piece3 = ColoredPiece::make (Color::None, Piece::None);
 
         // find which direction the king was castling in
-        direction = (Column (dst) - Column (src)) / 2;
+        direction = (dst.column() - src.column()) / 2;
 
-        ColoredPiece piece1 = board.pieceAt (Row (src), Column (dst) - direction);
-        ColoredPiece piece2 = board.pieceAt (Row (src), Column (dst));
+        ColoredPiece piece1 = board.pieceAt (src.row(), dst.column() - direction);
+        ColoredPiece piece2 = board.pieceAt (src.row(), dst.column());
 
         if (direction < 0)
         {
             // check for piece next to rook on queenside
-            piece3 = board.pieceAt (Row (src), Column (dst) - 1);
+            piece3 = board.pieceAt (src.row(), dst.column() - 1);
         }
 
         return pieceType (piece1) == Piece::None && pieceType (piece2) == Piece::None

--- a/engine/src/move.hpp
+++ b/engine/src/move.hpp
@@ -193,10 +193,10 @@ namespace wisdom
             -> Move
         {
             return Move::makeCastling (
-                Row (src), 
-                Column (src), 
-                Row (dst), 
-                Column (dst)
+                src.row(),
+                src.column(),
+                dst.row(),
+                dst.column()
             );
         }
 
@@ -226,7 +226,7 @@ namespace wisdom
         ) noexcept 
             -> Move
         {
-            return Move::makeEnPassant (Row (src), Column (src), Row (dst), Column (dst));
+            return Move::makeEnPassant (src.row(), src.column(), dst.row(), dst.column());
         }
 
         [[nodiscard]] static constexpr auto 
@@ -340,7 +340,7 @@ namespace wisdom
         isCastlingOnKingside() const noexcept 
             -> bool
         {
-            return isCastling() && Column (getDst()) == Kingside_Castled_King_Column;
+            return isCastling() && getDst().column() == Kingside_Castled_King_Column;
         }
     };
 

--- a/engine/src/position.cpp
+++ b/engine/src/position.cpp
@@ -76,8 +76,8 @@ namespace wisdom
         if (who == Color::White)
             return coord;
 
-        int8_t row = Row (coord);
-        int8_t col = Column (coord);
+        int8_t row = coord.row();
+        int8_t col = coord.column();
 
         return makeCoord (
             gsl::narrow_cast<int8_t> (Last_Row - row),
@@ -101,8 +101,8 @@ namespace wisdom
     static int change (Coord coord, Color who, ColoredPiece piece)
     {
         Coord translated_pos = translatePosition (coord, who);
-        int8_t row = Row (translated_pos);
-        int8_t col = Column (translated_pos);
+        int8_t row = translated_pos.row();
+        int8_t col = translated_pos.column();
 
         // todo convert enum to integer index instead of using switch.
         switch (pieceType (piece))

--- a/engine/src/threats.hpp
+++ b/engine/src/threats.hpp
@@ -27,8 +27,8 @@ namespace wisdom
             : my_board { board }
             , my_opponent { colorInvert (king_color) }
             , my_king_color { king_color }
-            , my_king_row { Row (king_coord) }
-            , my_king_col { Column (king_coord) }
+            , my_king_row { king_coord.row() }
+            , my_king_col { king_coord.column() }
         {
         }
 

--- a/engine/test/board_builder_test.cpp
+++ b/engine/test/board_builder_test.cpp
@@ -12,14 +12,14 @@ TEST_CASE( "board_builder" )
 {
     SUBCASE( "Specifying coordinates in algebraic notation" )
     {
-        CHECK( Row (coordParse ("a8")) == 0 );
-        CHECK( Row (coordParse ("a1")) == 7 );
-        CHECK( Column (coordParse ("a8")) == 0 );
-        CHECK( Column (coordParse ("a1")) == 0 );
-        CHECK( Row (coordParse ("h1")) == 7 );
-        CHECK( Row (coordParse ("h8")) == 0 );
-        CHECK( Column (coordParse ("h1")) == 7 );
-        CHECK( Column (coordParse ("h8")) == 7 );
+        CHECK( coordRow (coordParse ("a8")) == 0 );
+        CHECK( coordRow (coordParse ("a1")) == 7 );
+        CHECK( coordColumn (coordParse ("a8")) == 0 );
+        CHECK( coordColumn (coordParse ("a1")) == 0 );
+        CHECK( coordRow (coordParse ("h1")) == 7 );
+        CHECK( coordRow (coordParse ("h8")) == 0 );
+        CHECK( coordColumn (coordParse ("h1")) == 7 );
+        CHECK( coordColumn (coordParse ("h8")) == 7 );
     }
 
     SUBCASE( "Initializing the board builder" )

--- a/engine/test/castle_test.cpp
+++ b/engine/test/castle_test.cpp
@@ -135,8 +135,8 @@ TEST_CASE( "Castling state is modified and restored for castling queenside" )
     CHECK( board.getCastlingEligibility (Color::Black) == Neither_Side_Eligible );
 
     // Check rook and king position updated:
-    CHECK( Row (board.getKingPosition (Color::Black)) == 0 );
-    CHECK( Column (board.getKingPosition (Color::Black)) == 2 );
+    CHECK( coordRow (board.getKingPosition (Color::Black)) == 0 );
+    CHECK( coordColumn (board.getKingPosition (Color::Black)) == 2 );
     CHECK( pieceType (board.pieceAt (0, 2)) == Piece::King );
     CHECK( pieceColor (board.pieceAt (0, 2)) == Color::Black );
     CHECK( pieceType (board.pieceAt (0, 3)) == Piece::Rook );
@@ -173,8 +173,8 @@ TEST_CASE("Castling state is modified and restored for castling kingside")
     CHECK( board.getCastlingEligibility (Color::White) == Neither_Side_Eligible );
 
     // Check rook and king position updated:
-    CHECK( Row (board.getKingPosition (Color::White)) == 7 );
-    CHECK( Column (board.getKingPosition (Color::White)) == 6 );
+    CHECK( coordRow (board.getKingPosition (Color::White)) == 7 );
+    CHECK( coordColumn (board.getKingPosition (Color::White)) == 6 );
     CHECK( pieceType (board.pieceAt (7, 6)) == Piece::King );
     CHECK( pieceColor (board.pieceAt (7, 6)) == Color::White );
     CHECK( pieceType (board.pieceAt (7, 5)) == Piece::Rook );

--- a/engine/test/coord_test.cpp
+++ b/engine/test/coord_test.cpp
@@ -10,8 +10,8 @@ TEST_CASE( "A coordinate can be generated" )
         for (int8_t col = 0; col < 8; col++) {
             Coord coord = makeCoord (row, col);
 
-            CHECK( Row (coord) == row );
-            CHECK( Column (coord) == col );
+            CHECK( coordRow (coord) == row );
+            CHECK( coordColumn (coord) == col );
         }
     }
 }
@@ -19,12 +19,12 @@ TEST_CASE( "A coordinate can be generated" )
 
 TEST_CASE( "Coord_parse specifying coordinates in algebraic notation" )
 {
-    CHECK( Row (coordParse ("a8")) == 0 );
-    CHECK( Row (coordParse ("a1")) == 7 );
-    CHECK( Column (coordParse ("a8")) == 0 );
-    CHECK( Column (coordParse ("a1")) == 0 );
-    CHECK( Row (coordParse ("h1")) == 7 );
-    CHECK( Row (coordParse ("h8")) == 0 );
-    CHECK( Column (coordParse ("h1")) == 7 );
-    CHECK( Column (coordParse ("h8")) == 7 );
+    CHECK( coordRow (coordParse ("a8")) == 0 );
+    CHECK( coordRow (coordParse ("a1")) == 7 );
+    CHECK( coordColumn (coordParse ("a8")) == 0 );
+    CHECK( coordColumn (coordParse ("a1")) == 0 );
+    CHECK( coordRow (coordParse ("h1")) == 7 );
+    CHECK( coordRow (coordParse ("h8")) == 0 );
+    CHECK( coordColumn (coordParse ("h1")) == 7 );
+    CHECK( coordColumn (coordParse ("h8")) == 7 );
 }

--- a/engine/test/en_passant_test.cpp
+++ b/engine/test/en_passant_test.cpp
@@ -66,10 +66,10 @@ TEST_CASE( "en passant" )
         REQUIRE( en_passant_move.isEnPassant() );
 
         // Check position:
-        REQUIRE( Row (en_passant_move.getSrc()) == 3 );
-        REQUIRE( Column (en_passant_move.getSrc()) == 4 );
-        REQUIRE( Row (en_passant_move.getDst()) == 2 );
-        REQUIRE( Column (en_passant_move.getDst()) == 5 );
+        REQUIRE( coordRow (en_passant_move.getSrc()) == 3 );
+        REQUIRE( coordColumn (en_passant_move.getSrc()) == 4 );
+        REQUIRE( coordRow (en_passant_move.getDst()) == 2 );
+        REQUIRE( coordColumn (en_passant_move.getDst()) == 5 );
 
         REQUIRE( board.isEnPassantVulnerable (Color::Black) );
         REQUIRE( !board.isEnPassantVulnerable (Color::White) );
@@ -115,10 +115,10 @@ TEST_CASE( "en passant" )
         REQUIRE( en_passant_move.isEnPassant() );
 
         // Check position:
-        REQUIRE( Row (en_passant_move.getSrc()) == 3 );
-        REQUIRE( Column (en_passant_move.getSrc()) == 4 );
-        REQUIRE( Row (en_passant_move.getDst()) == 2 );
-        REQUIRE( Column (en_passant_move.getDst()) == 3 );
+        REQUIRE( coordRow (en_passant_move.getSrc()) == 3 );
+        REQUIRE( coordColumn (en_passant_move.getSrc()) == 4 );
+        REQUIRE( coordRow (en_passant_move.getDst()) == 2 );
+        REQUIRE( coordColumn (en_passant_move.getDst()) == 3 );
 
         REQUIRE( board.isEnPassantVulnerable (Color::Black) );
         REQUIRE( !board.isEnPassantVulnerable (Color::White) );

--- a/engine/test/move_parse_test.cpp
+++ b/engine/test/move_parse_test.cpp
@@ -17,8 +17,8 @@ TEST_CASE( "moveParse" )
     SUBCASE( "color matters in moveParse" )
     {
         Move castle = moveParse ("o-o", Color::Black);
-        CHECK( Row (castle.getSrc()) == 0 );
-        CHECK( Row (castle.getDst()) == 0 );
+        CHECK( coordRow (castle.getSrc()) == 0 );
+        CHECK( coordRow (castle.getDst()) == 0 );
         CHECK( moveEquals (castle, moveParse ("o-o", Color::Black)) );
     }
 

--- a/engine/test/move_test.cpp
+++ b/engine/test/move_test.cpp
@@ -27,7 +27,7 @@ TEST_CASE( "Parsing an en-passant move" )
     Move en_passant = moveParse ("   e4d5 ep   ", Color::White);
     Coord src = coordParse ("e4");
     Coord dst = coordParse ("d5");
-    Move expected = Move::makeEnPassant (Row (src), Column (src), Row (dst), Column (dst));
+    Move expected = Move::makeEnPassant (src.row(), src.column(), dst.row(), dst.column());
     REQUIRE( en_passant == expected );
 }
 
@@ -46,7 +46,7 @@ TEST_CASE( "Parsing a castling move" )
     Move castling = moveParse ("   o-o-o ", Color::Black);
     Coord src = coordParse ("e8");
     Coord dst = coordParse ("c8");
-    Move expected = Move::makeCastling (Row (src), Column (src), Row (dst), Column (dst));
+    Move expected = Move::makeCastling (src.row(), src.column(), dst.row(), dst.column());
 
     REQUIRE( castling == expected );
 }

--- a/engine/test/perft.cpp
+++ b/engine/test/perft.cpp
@@ -68,8 +68,8 @@ namespace wisdom
         {
             int castling_row
                 = pieceColor (src_piece) == Color::White ? wisdom::Last_Row : wisdom::First_Row;
-            if (castling_row == Row (src) && castling_row == Row (dst)
-                && std::abs (Column (src) - Column (dst)))
+            if (castling_row == src.row() && castling_row == dst.row()
+                && std::abs (src.column() - dst.column()))
             {
                 result = Move::makeCastling (src, dst);
             }
@@ -78,7 +78,7 @@ namespace wisdom
         // 2. en-passant is represented without (ep) suffix
         if (wisdom::pieceType (src_piece) == Piece::Pawn)
         {
-            if (Row (src) != Row (dst) && Column (src) != Column (dst)
+            if (src.row() != dst.row() && src.column() != dst.column()
                 && dst_piece == Piece_And_Color_None)
             {
                 result = Move::makeEnPassant (src, dst);

--- a/ui/qml/main/pieces_model.cpp
+++ b/ui/qml/main/pieces_model.cpp
@@ -131,10 +131,10 @@ void PiecesModel::playerMoved (Move selected_move, wisdom::Color who)
     Coord src = selected_move.getSrc();
     Coord dst = selected_move.getDst();
 
-    int src_row = Row<int> (src);
-    int src_column = Column<int> (src);
-    int dst_row = Row<int> (dst);
-    int dst_column = Column<int> (dst);
+    int src_row = coordRow<int> (src);
+    int src_column = coordColumn<int> (src);
+    int dst_row = coordRow<int> (dst);
+    int dst_column = coordColumn<int> (dst);
 
     auto count = my_pieces.count();
     for (int i = 0; i < count; i++)

--- a/ui/wasm/bindings.cpp
+++ b/ui/wasm/bindings.cpp
@@ -218,7 +218,8 @@ void workerReceiveSettings (int white_player, int black_player, int thinking_tim
     auto state = GameState::getState();
 
     state->updateSettings (GameSettings { static_cast<WebPlayer> (white_player),
-                                          static_cast<WebPlayer> (black_player), thinking_time,
+                                          static_cast<WebPlayer> (black_player), 
+                                          thinking_time,
                                           search_depth });
 
     startSearch();

--- a/ui/wasm/web_game.cpp
+++ b/ui/wasm/web_game.cpp
@@ -20,8 +20,8 @@ namespace wisdom
             {
                 WebColoredPiece new_piece
                     = WebColoredPiece { id, toInt (piece.color()), toInt (piece.type()),
-                                        gsl::narrow<int> (Row (coord)),
-                                        gsl::narrow<int> (Column (coord)) };
+                                        gsl::narrow<int> (coord.row()),
+                                        gsl::narrow<int> (coord.column()) };
                 my_pieces.addPiece (new_piece);
                 id++;
             }
@@ -176,8 +176,8 @@ namespace wisdom
                         id,
                         toInt (piece.color()),
                         toInt (piece.type()),
-                        gsl::narrow<int8_t> (Row (coord)),
-                        gsl::narrow<int8_t> (Column (coord)),
+                        gsl::narrow<int8_t> (coord.row()),
+                        gsl::narrow<int8_t> (coord.column()),
                     };
                     my_pieces.addPiece (new_piece);
                 }
@@ -218,8 +218,8 @@ namespace wisdom
                     old_piece.id,
                     old_piece.color,
                     mapPiece (new_piece.type()),
-                    Row<int8_t> (coord),
-                    Column<int8_t> (coord),
+                    coord.row<int8_t>(),
+                    coord.column<int8_t>(),
                 });
             }
         }

--- a/ui/wasm/web_types.hpp
+++ b/ui/wasm/web_types.hpp
@@ -285,8 +285,8 @@ namespace wisdom
         static auto fromTextCoord (char* coord_text) -> WebCoord*
         {
             auto coord = coordParse (coord_text);
-            return new WebCoord { gsl::narrow<int> (Row (coord)),
-                                  gsl::narrow<int> (Column (coord)) };
+            return new WebCoord { gsl::narrow<int> (coord.row()),
+                                  gsl::narrow<int> (coord.column()) };
         }
     };
 


### PR DESCRIPTION
- Replace most uses of Row()/Column() functions with coord.row() and coord.column()
- For remaining usages, rename Row()/Column() to coordRow() and coordColumn()