### PR TITLE
Remove No_En_Passant_Coord

### DIFF
--- a/engine/src/board.cpp
+++ b/engine/src/board.cpp
@@ -204,10 +204,10 @@ namespace wisdom
         output += both_castled;
 
         auto en_passant_targets = getEnPassantTargets();
-        if (en_passant_targets[Color_Index_White] != No_En_Passant_Coord)
-            output += " " + wisdom::asString (en_passant_targets[Color_Index_White]) + " ";
-        else if (en_passant_targets[Color_Index_Black] != No_En_Passant_Coord)
-            output += " " + wisdom::asString (en_passant_targets[Color_Index_Black]) + " ";
+        if (en_passant_targets[Color_Index_White] != nullopt)
+            output += " " + wisdom::asString (*en_passant_targets[Color_Index_White]) + " ";
+        else if (en_passant_targets[Color_Index_Black] != nullopt)
+            output += " " + wisdom::asString (*en_passant_targets[Color_Index_Black]) + " ";
         else
             output += " - ";
 

--- a/engine/src/board.hpp
+++ b/engine/src/board.hpp
@@ -22,79 +22,114 @@ namespace wisdom
 
         explicit Board (const BoardBuilder& builder);
 
-        friend auto operator== (const Board& a, const Board& b) -> bool
+        friend auto
+        operator== (const Board& a, const Board& b)
+            -> bool
         {
             return a.my_code == b.my_code && a.my_squares == b.my_squares;
         }
 
-        [[nodiscard]] constexpr auto pieceAt (int row, int col) const -> ColoredPiece
+        [[nodiscard]] constexpr auto
+        pieceAt (int row, int col) const
+            -> ColoredPiece
         {
             Coord coord = Coord::make (row, col);
             return my_squares[coord.index()];
         }
 
-        [[nodiscard]] constexpr auto pieceAt (Coord coord) const -> ColoredPiece
+        [[nodiscard]] constexpr auto
+        pieceAt (Coord coord) const
+            -> ColoredPiece
         {
             return my_squares[coord.index()];
         }
 
-        friend auto operator<< (std::ostream& os, const Board& board) -> std::ostream&;
+        friend auto
+        operator<< (std::ostream& os, const Board& board)
+            -> std::ostream&;
 
         void dump() const;
 
-        [[nodiscard]] auto getHalfMoveClock() const noexcept -> int
+        [[nodiscard]] auto
+        getHalfMoveClock() const noexcept
+            -> int
         {
             return my_half_move_clock;
         }
 
-        [[nodiscard]] auto getFullMoveClock() const noexcept -> int
+        [[nodiscard]] auto
+        getFullMoveClock() const noexcept
+            -> int
         {
             return my_full_move_clock;
         }
 
         // Convert the board to a string.
-        [[nodiscard]] auto asString() const -> string;
+        [[nodiscard]] auto
+        asString() const
+            -> string;
 
-        [[nodiscard]] auto getCode() const noexcept -> BoardCode
+        [[nodiscard]] auto
+        getCode() const noexcept
+            -> BoardCode
         {
             return my_code;
         }
 
-        [[nodiscard]] auto getMaterial() const& noexcept -> const Material&
+        [[nodiscard]] auto
+        getMaterial() const& noexcept
+            -> const Material&
         {
             return my_material;
         }
         void getMaterial() const&& = delete;
 
-        [[nodiscard]] auto getPosition() const& noexcept -> const Position&
+        [[nodiscard]] auto
+        getPosition() const& noexcept
+            -> const Position&
         {
             return my_position;
         }
         void getPosition() const&& = delete;
 
-        [[nodiscard]] auto toFenString (Color turn) const -> string;
-        [[nodiscard]] auto castledString (Color color) const -> string;
+        [[nodiscard]] auto
+        toFenString (Color turn) const
+            -> string;
+        [[nodiscard]] auto
+        castledString (Color color) const
+            -> string;
 
         // Create a new board with the move applied:
-        [[nodiscard]] auto withMove (Color who, Move move) const -> Board;
+        [[nodiscard]] auto
+        withMove (Color who, Move move) const
+            -> Board;
 
         // Create a new board with the current turn updated:
-        [[nodiscard]] auto withCurrentTurn (Color who) const -> Board;
+        [[nodiscard]] auto
+        withCurrentTurn (Color who) const
+            -> Board;
 
         // Randomize and return copy of current board:
-        [[nodiscard]] auto withRandomPosition() const -> Board;
+        [[nodiscard]] auto
+        withRandomPosition() const
+            -> Board;
 
-        [[nodiscard]] auto getKingPosition (Color who) const noexcept -> Coord
+        [[nodiscard]] auto
+        getKingPosition (Color who) const noexcept
+            -> Coord
         {
             return my_king_pos[colorIndex (who)];
         }
 
-        [[nodiscard]] auto getCastlingEligibility (Color who) const noexcept -> CastlingEligibility
+        [[nodiscard]] auto
+        getCastlingEligibility (Color who) const noexcept
+            -> CastlingEligibility
         {
             return my_code.castleState (who);
         }
 
-        [[nodiscard]] auto ableToCastle (Color who, CastlingEligibility castle_types) const noexcept
+        [[nodiscard]] auto
+        ableToCastle (Color who, CastlingEligibility castle_types) const noexcept
             -> bool
         {
             // If either/both is passed, check both types.
@@ -162,8 +197,12 @@ namespace wisdom
         void clearEnPassantTargets() noexcept;
 
         [[nodiscard]] auto getCastlingRookMove (Move move, Color who) const -> Move;
-        void applyForCastlingMove (Color who, Move king_move, [[maybe_unused]] Coord src,
-                                   [[maybe_unused]] Coord dst) noexcept;
+        void applyForCastlingMove (
+            Color who,
+            Move king_move,
+            [[maybe_unused]] Coord src,
+            [[maybe_unused]] Coord dst
+        ) noexcept;
         void updateAfterKingMove (Color who, [[maybe_unused]] Coord src, Coord dst);
         void setCastleState (Color who, CastlingEligibility new_state) noexcept;
 

--- a/engine/src/board.hpp
+++ b/engine/src/board.hpp
@@ -112,7 +112,7 @@ namespace wisdom
 
         [[nodiscard]] auto isEnPassantVulnerable (Color who) const noexcept -> bool
         {
-            return my_code.enPassantTarget (who) != No_En_Passant_Coord;
+            return my_code.enPassantTarget (who) != nullopt;
         }
 
         [[nodiscard]] auto getCurrentTurn() const -> Color
@@ -120,12 +120,16 @@ namespace wisdom
             return my_code.currentTurn();
         }
 
-        [[nodiscard]] auto getEnPassantTarget (Color who) const noexcept -> Coord
+        [[nodiscard]] auto
+        getEnPassantTarget (Color who) const noexcept
+            -> optional<Coord>
         {
             return my_code.enPassantTarget (who);
         }
 
-        [[nodiscard]] auto getEnPassantTargets() const noexcept -> EnPassantTargets
+        [[nodiscard]] auto
+        getEnPassantTargets() const noexcept
+            -> EnPassantTargets
         {
             return my_code.enPassantTargets();
         }
@@ -135,13 +139,18 @@ namespace wisdom
             return my_code;
         }
 
-        [[nodiscard]] static auto allCoords() -> CoordIterator
+        [[nodiscard]] static auto
+        allCoords()
+            -> CoordIterator
         {
             return CoordIterator {};
         }
 
         [[nodiscard]] auto
-        findFirstCoordWithPiece (ColoredPiece piece, Coord starting_at = First_Coord) const
+        findFirstCoordWithPiece (
+            ColoredPiece piece,
+            Coord starting_at = First_Coord
+        ) const
             -> optional<Coord>;
 
     private:
@@ -150,17 +159,33 @@ namespace wisdom
         auto applyForEnPassant (Color who, Coord src, Coord dst) noexcept -> ColoredPiece;
         void updateEnPassantEligibility (Color who, ColoredPiece src_piece, Move move) noexcept;
         void setEnPassantTarget (Color who, Coord target) noexcept;
+        void clearEnPassantTargets() noexcept;
 
         [[nodiscard]] auto getCastlingRookMove (Move move, Color who) const -> Move;
         void applyForCastlingMove (Color who, Move king_move, [[maybe_unused]] Coord src,
                                    [[maybe_unused]] Coord dst) noexcept;
         void updateAfterKingMove (Color who, [[maybe_unused]] Coord src, Coord dst);
         void setCastleState (Color who, CastlingEligibility new_state) noexcept;
-        void removeCastlingEligibility (Color who,
-                                        CastlingEligibility removed_castle_states) noexcept;
-        void updateAfterRookCapture (Color opponent, ColoredPiece dst_piece, Coord src, Coord dst) noexcept;
-        void updateAfterRookMove (Color player, ColoredPiece src_piece,
-                                  Move move, Coord src, Coord dst) noexcept;
+
+        void removeCastlingEligibility (
+            Color who,
+            CastlingEligibility removed_castle_states
+        ) noexcept;
+
+        void updateAfterRookCapture (
+            Color opponent,
+            ColoredPiece dst_piece,
+            Coord src,
+            Coord dst
+        ) noexcept;
+
+        void updateAfterRookMove (
+            Color player,
+            ColoredPiece src_piece,
+            Move move,
+            Coord src,
+            Coord dst
+        ) noexcept;
 
         void setKingPosition (Color who, Coord pos) noexcept;
         void setPiece (Coord coord, ColoredPiece piece) noexcept;

--- a/engine/src/board_builder.hpp
+++ b/engine/src/board_builder.hpp
@@ -88,7 +88,7 @@ namespace wisdom
             return my_current_turn;
         }
 
-        [[nodiscard]] auto getEnPassantTargets() const -> array<Coord, Num_Players>
+        [[nodiscard]] auto getEnPassantTargets() const -> array<optional<Coord>, Num_Players>
         {
             return my_en_passant_targets;
         }
@@ -141,9 +141,9 @@ namespace wisdom
             nullopt 
         };
 
-        array<Coord, Num_Players> my_en_passant_targets { 
-            No_En_Passant_Coord,
-            No_En_Passant_Coord 
+        array<optional<Coord>, Num_Players> my_en_passant_targets {
+            nullopt,
+            nullopt
         };
 
         array<optional<Coord>, Num_Players> my_king_positions { 

--- a/engine/src/board_code.cpp
+++ b/engine/src/board_code.cpp
@@ -34,18 +34,17 @@ namespace wisdom
         setCurrentTurn (current_turn);
 
         auto en_passant_targets = board.getEnPassantTargets();
-        if (en_passant_targets[Color_Index_White] != No_En_Passant_Coord)
+        if (en_passant_targets[Color_Index_White] != nullopt)
         {
-            setEnPassantTarget (Color::White, en_passant_targets[Color_Index_White]);
+            setEnPassantTarget (Color::White, *en_passant_targets[Color_Index_White]);
         }
-        else if (en_passant_targets[Color_Index_Black] != No_En_Passant_Coord)
+        else if (en_passant_targets[Color_Index_Black] != nullopt)
         {
-            setEnPassantTarget (Color::Black, en_passant_targets[Color_Index_Black]);
+            setEnPassantTarget (Color::Black, *en_passant_targets[Color_Index_Black]);
         }
         else
         {
-            // this clears both targets:
-            setEnPassantTarget (Color::White, No_En_Passant_Coord);
+            clearEnPassantTargets ();
         }
 
         setCastleState (Color::White, board.getCastlingEligibility (Color::White));
@@ -71,17 +70,17 @@ namespace wisdom
         result.setCurrentTurn (current_turn);
 
         auto en_passant_targets = builder.getEnPassantTargets();
-        if (en_passant_targets[Color_Index_White] != No_En_Passant_Coord)
+        if (en_passant_targets[Color_Index_White] != nullopt)
         {
-            result.setEnPassantTarget (Color::White, en_passant_targets[Color_Index_White]);
+            result.setEnPassantTarget (Color::White, *en_passant_targets[Color_Index_White]);
         }
-        else if (en_passant_targets[Color_Index_Black] != No_En_Passant_Coord)
+        else if (en_passant_targets[Color_Index_Black] != nullopt)
         {
-            result.setEnPassantTarget (Color::Black, en_passant_targets[Color_Index_Black]);
+            result.setEnPassantTarget (Color::Black, *en_passant_targets[Color_Index_Black]);
         }
         else
         {
-            result.setEnPassantTarget (Color::White, No_En_Passant_Coord);
+            result.clearEnPassantTargets();
         }
 
         result.setCastleState (Color::White, builder.getCastleState (Color::White));

--- a/engine/src/board_code.hpp
+++ b/engine/src/board_code.hpp
@@ -135,7 +135,7 @@ namespace wisdom
             target_bits &= EN_PASSANT_MASK << EN_PASSANT_WHITE_TARGET;
             target_bits >>= target_bit_shift;
             auto col = gsl::narrow<int8_t> (target_bits & 0x7);
-            auto is_present = (bool)(target_bits & EN_PASSANT_PRESENT);
+            bool is_present = ((target_bits & EN_PASSANT_PRESENT) > 0);
             auto row = vulnerable_color == Color::White 
                 ? White_En_Passant_Row 
                 : Black_En_Passant_Row;
@@ -189,7 +189,9 @@ namespace wisdom
             -> Color
         {
             auto bits = getMetadataBits();
-            auto index = gsl::narrow_cast<int8_t> (bits & (CURRENT_TURN_MASK << CURRENT_TURN_BIT));
+            auto index = gsl::narrow_cast<int8_t> (
+                bits & (CURRENT_TURN_MASK << CURRENT_TURN_BIT)
+            );
             return colorFromColorIndex (index);
         }
 

--- a/engine/src/board_code.hpp
+++ b/engine/src/board_code.hpp
@@ -76,10 +76,12 @@ namespace wisdom
         fromBoardBuilder (const BoardBuilder& builder)
             -> BoardCode;
 
-        [[nodiscard]] static auto fromDefaultPosition()
+        [[nodiscard]] static auto
+        fromDefaultPosition()
             -> BoardCode;
 
-        [[nodiscard]] static auto fromEmptyBoard()
+        [[nodiscard]] static auto
+        fromEmptyBoard()
             -> BoardCode;
 
         void addPiece (Coord coord, ColoredPiece piece) noexcept

--- a/engine/src/board_code.hpp
+++ b/engine/src/board_code.hpp
@@ -17,7 +17,9 @@ namespace wisdom
 
     using BoardCodeArray = array<uint64_t, (Num_Players + 1) * Num_Piece_Types * Num_Squares>;
 
-    [[nodiscard]] constexpr auto initializeBoardCodes() -> BoardCodeArray
+    [[nodiscard]] constexpr auto
+    initializeBoardCodes()
+        -> BoardCodeArray
     {
         BoardCodeArray code_array {};
         CompileTimeRandom random;
@@ -35,7 +37,9 @@ namespace wisdom
 
     inline constexpr int Total_Metadata_Bits = 16;
 
-    [[nodiscard]] constexpr auto boardCodeHash (Coord coord, ColoredPiece piece) -> std::uint64_t
+    [[nodiscard]] constexpr auto
+    boardCodeHash (Coord coord, ColoredPiece piece)
+        -> std::uint64_t
     {
         auto coord_index = coord.index();
         auto piece_color = piece.color();
@@ -64,13 +68,19 @@ namespace wisdom
     public:
         explicit BoardCode (const Board& board);
 
-        [[nodiscard]] static auto fromBoard (const Board& board) -> BoardCode;
+        [[nodiscard]] static auto
+        fromBoard (const Board& board)
+            -> BoardCode;
 
-        [[nodiscard]] static auto fromBoardBuilder (const BoardBuilder& builder) -> BoardCode;
+        [[nodiscard]] static auto
+        fromBoardBuilder (const BoardBuilder& builder)
+            -> BoardCode;
 
-        [[nodiscard]] static auto fromDefaultPosition() -> BoardCode;
+        [[nodiscard]] static auto fromDefaultPosition()
+            -> BoardCode;
 
-        [[nodiscard]] static auto fromEmptyBoard() -> BoardCode;
+        [[nodiscard]] static auto fromEmptyBoard()
+            -> BoardCode;
 
         void addPiece (Coord coord, ColoredPiece piece) noexcept
         {
@@ -146,7 +156,9 @@ namespace wisdom
             setMetadataBits (metadataBits);
         }
 
-        [[nodiscard]] auto castleState (Color who) const -> CastlingEligibility
+        [[nodiscard]] auto
+        castleState (Color who) const
+            -> CastlingEligibility
         {
             auto target_bits = getMetadataBits();
             auto target_bit_shift = who == Color::White 
@@ -172,14 +184,18 @@ namespace wisdom
             setMetadataBits (metadataBits);
         }
 
-        [[nodiscard]] auto currentTurn() const noexcept -> Color
+        [[nodiscard]] auto
+        currentTurn() const noexcept
+            -> Color
         {
             auto bits = getMetadataBits();
             auto index = gsl::narrow_cast<int8_t> (bits & (CURRENT_TURN_MASK << CURRENT_TURN_BIT));
             return colorFromColorIndex (index);
         }
 
-        [[nodiscard]] auto enPassantTargets() const noexcept -> EnPassantTargets
+        [[nodiscard]] auto
+        enPassantTargets() const noexcept
+            -> EnPassantTargets
         {
             EnPassantTargets result = {
                 enPassantTarget (Color::White),
@@ -188,36 +204,50 @@ namespace wisdom
             return result;
         }
 
-        [[nodiscard]] auto getMetadataBits() const noexcept -> std::uint16_t
+        [[nodiscard]] auto
+        getMetadataBits() const noexcept
+            -> std::uint16_t
         {
             return gsl::narrow_cast<uint16_t> (my_code & 0xffff);
         }
 
-        [[nodiscard]] auto asString() const noexcept -> string
+        [[nodiscard]] auto
+        asString() const noexcept
+            -> string
         {
             std::bitset<64> bits { my_code };
 
             return bits.to_string();
         }
 
-        [[nodiscard]] auto hashCode() const noexcept -> BoardHashCode
+        [[nodiscard]] auto
+        hashCode() const noexcept
+            -> BoardHashCode
         {
             return my_code;
         }
 
-        friend auto operator== (const BoardCode& first, const BoardCode& second) noexcept -> bool
+        friend auto
+        operator== (const BoardCode& first, const BoardCode& second) noexcept
+            -> bool
         {
             return first.my_code == second.my_code;
         }
 
-        friend auto operator!= (const BoardCode& first, const BoardCode& second) noexcept -> bool
+        friend auto
+        operator!= (const BoardCode& first, const BoardCode& second) noexcept
+            -> bool
         {
             return !(first == second);
         }
 
-        friend auto operator<< (std::ostream& os, const BoardCode& code) -> std::ostream&;
+        friend auto
+        operator<< (std::ostream& os, const BoardCode& code)
+            -> std::ostream&;
 
-        [[nodiscard]] auto withMove (const Board& board, Move move) const noexcept -> BoardCode
+        [[nodiscard]] auto
+        withMove (const Board& board, Move move) const noexcept
+            -> BoardCode
         {
             auto copy = *this;
             copy.applyMove (board, move);
@@ -248,7 +278,9 @@ namespace std
     template <>
     struct hash<wisdom::BoardCode>
     {
-        auto operator() (const wisdom::BoardCode& code) const noexcept -> std::size_t
+        auto
+        operator() (const wisdom::BoardCode& code) const noexcept
+            -> std::size_t
         {
             return code.hashCode();
         }

--- a/engine/src/coord.hpp
+++ b/engine/src/coord.hpp
@@ -90,7 +90,6 @@ namespace wisdom
 
     constexpr Coord First_Coord = makeCoord (0, 0);
     constexpr Coord End_Coord = { .row_and_col = Num_Squares };
-    constexpr Coord No_En_Passant_Coord = First_Coord;
 
     template <typename IntegerType = int8_t>
     [[nodiscard]] constexpr auto coordRow (Coord pos) -> IntegerType

--- a/engine/src/game.hpp
+++ b/engine/src/game.hpp
@@ -47,8 +47,8 @@ namespace wisdom
         Game& operator= (const Game& other) = default;
 
         // Default move:
-        Game (Game&& other) = default;
-        Game& operator= (Game&& other) = default;
+        Game (Game&& other) noexcept = default;
+        Game& operator= (Game&& other) noexcept = default;
 
         static auto load (const string& filename, const Players& players) -> optional<Game>;
 

--- a/engine/src/generate.cpp
+++ b/engine/src/generate.cpp
@@ -263,8 +263,11 @@ namespace wisdom
     {
         Color opponent = colorInvert (who);
 
-        if (!board.isEnPassantVulnerable (opponent))
+        auto enPassantTarget = board.getEnPassantTarget (opponent);
+        if (!enPassantTarget.has_value())
             return nullopt;
+
+        Coord target_coord = *enPassantTarget;
 
         // if WHITE rank 4, black rank 3
         if ((who == Color::White ? 3 : 4) != row)
@@ -272,7 +275,7 @@ namespace wisdom
 
         int left_column = column - 1;
         int right_column = column + 1;
-        int target_column = coordColumn<int> (board.getEnPassantTarget (opponent));
+        int target_column = target_coord.column<int>();
 
         if (left_column == target_column)
         {

--- a/engine/src/move.cpp
+++ b/engine/src/move.cpp
@@ -243,14 +243,13 @@ namespace wisdom
     Board::updateEnPassantEligibility (Color who, ColoredPiece src_piece, Move move) noexcept
     {
         int direction = pawnDirection<int> (who);
-        optional<Coord> new_state = nullopt;
 
         if (isDoubleSquarePawnMove (src_piece, move))
         {
             Coord src = move.getSrc();
             int prev_row = nextRow (src.row<int>(), direction);
-            new_state = makeCoord (prev_row, src.column());
-            setEnPassantTarget (who, *new_state);
+            Coord new_state = makeCoord (prev_row, src.column());
+            setEnPassantTarget (who, new_state);
         }
         else
         {

--- a/engine/src/move.cpp
+++ b/engine/src/move.cpp
@@ -19,15 +19,17 @@ namespace wisdom
     {
         Coord src = move.getSrc();
         Coord dst = move.getDst();
-        return pieceType (src_piece) == Piece::Pawn && abs (src.row() - dst.row()) == 2;
+        return pieceType (src_piece) == Piece::Pawn
+            && abs (src.row() - dst.row()) == 2;
     }
 
-    void 
+    auto
     Board::updateMoveClock (
         Color who, 
         Piece orig_src_piece_type, 
         Move move
     ) noexcept
+        -> void
     {
         if (move.isAnyCapturing() || orig_src_piece_type == Piece::Pawn)
             my_half_move_clock = 0;
@@ -101,18 +103,19 @@ namespace wisdom
             dst_col = dst.column() + 1;
         }
 
-        Expects (pieceType (pieceAt (src_row, src_col)) == Piece::Rook);
+        assert (pieceType (pieceAt (src_row, src_col)) == Piece::Rook);
 
         return Move::make (src_row, src_col, dst_row, dst_col);
     }
 
-    void 
+    auto
     Board::applyForCastlingMove (
         Color who, 
         Move king_move, 
         [[maybe_unused]] Coord src, 
         [[maybe_unused]] Coord dst
     ) noexcept
+        -> void
     {
         Move rook_move = getCastlingRookMove (king_move, who);
 
@@ -137,8 +140,12 @@ namespace wisdom
         my_code.setCastleState (who, new_state);
     }
 
-    void
-    Board::removeCastlingEligibility (Color who, CastlingEligibility removed_castle_states) noexcept
+    auto
+    Board::removeCastlingEligibility (
+        Color who,
+        CastlingEligibility removed_castle_states
+    ) noexcept
+        -> void
     {
         CastlingEligibility orig_castle_state = getCastlingEligibility (who);
         my_code.setCastleState (
@@ -163,15 +170,17 @@ namespace wisdom
         }
     }
 
-    void 
+    auto
     Board::updateAfterRookCapture (
         Color opponent,
         [[maybe_unused]] ColoredPiece dst_piece,
         [[maybe_unused]] Coord src,
         Coord dst
     ) noexcept
+        -> void
     {
-        Expects (pieceColor (dst_piece) == opponent && pieceType (dst_piece) == Piece::Rook);
+        assert (pieceColor (dst_piece) == opponent);
+        assert (pieceType (dst_piece) == Piece::Rook);
 
         optional<CastlingEligibility> castle_state = nullopt;
 
@@ -193,16 +202,18 @@ namespace wisdom
             removeCastlingEligibility (opponent, *castle_state);
     }
 
-    void 
+    auto
     Board::updateAfterRookMove (
         Color player, 
         ColoredPiece src_piece, 
         Move move, 
         Coord src, 
         Coord dst
-    ) noexcept 
+    ) noexcept
+        -> void
     {
-        Expects (pieceColor (src_piece) == player && pieceType (src_piece) == Piece::Rook);
+        assert (pieceColor (src_piece) == player);
+        assert (pieceType (src_piece) == Piece::Rook);
 
         CastlingEligibility affects_castle_state = Either_Side_Eligible;
         int castle_src_row = player == Color::White ? Last_Row : First_Row;

--- a/engine/src/move.cpp
+++ b/engine/src/move.cpp
@@ -233,18 +233,29 @@ namespace wisdom
         my_code.setEnPassantTarget (who, target);
     }
 
+    void
+    Board::clearEnPassantTargets() noexcept
+    {
+        my_code.clearEnPassantTargets();
+    }
+
     void 
     Board::updateEnPassantEligibility (Color who, ColoredPiece src_piece, Move move) noexcept
     {
         int direction = pawnDirection<int> (who);
-        Coord new_state = No_En_Passant_Coord;
+        optional<Coord> new_state = nullopt;
+
         if (isDoubleSquarePawnMove (src_piece, move))
         {
             Coord src = move.getSrc();
             int prev_row = nextRow (src.row<int>(), direction);
             new_state = makeCoord (prev_row, src.column());
+            setEnPassantTarget (who, *new_state);
         }
-        setEnPassantTarget (who, new_state);
+        else
+        {
+            clearEnPassantTargets();
+        }
     }
 
     [[nodiscard]] auto 

--- a/engine/src/move.hpp
+++ b/engine/src/move.hpp
@@ -358,26 +358,21 @@ namespace wisdom
 
     using PlayerCastleState = array<CastlingEligibility, Num_Players>;
 
-    [[nodiscard]] constexpr auto 
-    moveEquals (Move a, Move b) noexcept 
+    constexpr auto
+    operator== (Move a, Move b) noexcept
         -> bool
     {
-        return a.src == b.src && a.dst == b.dst && a.promoted_piece == b.promoted_piece
+        return a.src == b.src
+            && a.dst == b.dst
+            && a.promoted_piece == b.promoted_piece
             && a.move_category == b.move_category;
     }
 
-    constexpr auto 
-    operator== (Move a, Move b) noexcept 
-        -> bool
-    {
-        return moveEquals (a, b);
-    }
-
-    constexpr auto 
+    constexpr auto
     operator!= (Move a, Move b) noexcept 
         -> bool
     {
-        return !moveEquals (a, b);
+        return !operator== (a, b);
     }
 
     // Parse a move. Returns empty if the parse failed.

--- a/engine/src/move_list.hpp
+++ b/engine/src/move_list.hpp
@@ -116,7 +116,7 @@ namespace wisdom
         auto operator== (const MoveList& other) const -> bool
         {
             return size() == other.size() &&
-                std::equal (begin(), end(), other.begin(), moveEquals);
+                std::equal (begin(), end(), other.begin());
         }
 
         auto operator!= (const MoveList& other) const -> bool

--- a/engine/test/board_code_test.cpp
+++ b/engine/test/board_code_test.cpp
@@ -200,12 +200,11 @@ TEST_CASE( "Board code stores metadata" )
         auto en_passant_target = with_state_code.enPassantTarget (Color::Black);
         auto expected_coord = coordParse ("d6");
         auto metadata = with_state_code.getMetadataBits();
-        INFO( metadata );
-        INFO( wisdom::asString (en_passant_target) );
-        CHECK( en_passant_target == expected_coord );
+        REQUIRE( en_passant_target.has_value() );
+        CHECK( *en_passant_target == expected_coord );
 
         auto opponent_target = with_state_code.enPassantTarget (Color::White);
-        CHECK( opponent_target == No_En_Passant_Coord );
+        CHECK( opponent_target == nullopt );
     }
 
     SUBCASE( "Board code stores en passant state for White" )
@@ -229,13 +228,11 @@ TEST_CASE( "Board code stores metadata" )
 
         auto expected_coord = coordParse ("e3");
         auto metadata = with_state_code.getMetadataBits();
-        CHECK( en_passant_target == expected_coord );
+        REQUIRE( en_passant_target.has_value() );
+        CHECK( *en_passant_target == expected_coord );
 
         auto opponent_target = with_state_code.enPassantTarget (Color::Black);
-        INFO( metadata );
-        INFO( wisdom::asString (opponent_target) );
-
-        CHECK( opponent_target == No_En_Passant_Coord );
+        CHECK( opponent_target == nullopt );
     }
 
     SUBCASE( "Board code stores castle state" )

--- a/engine/test/en_passant_test.cpp
+++ b/engine/test/en_passant_test.cpp
@@ -16,8 +16,8 @@ TEST_CASE( "en passant" )
         REQUIRE( !board.isEnPassantVulnerable (Color::White) );
         REQUIRE( !board.isEnPassantVulnerable (Color::Black) );
 
-        REQUIRE( board.getEnPassantTarget (Color::White) == No_En_Passant_Coord );
-        REQUIRE( board.getEnPassantTarget (Color::Black) == No_En_Passant_Coord );
+        REQUIRE( board.getEnPassantTarget (Color::White) == nullopt );
+        REQUIRE( board.getEnPassantTarget (Color::Black) == nullopt );
 
         BoardBuilder builder;
         const auto& back_rank = BoardBuilder::Default_Piece_Row;

--- a/engine/test/move_parse_test.cpp
+++ b/engine/test/move_parse_test.cpp
@@ -10,16 +10,16 @@ TEST_CASE( "moveParse" )
         Move capture = moveParse ("a6xb7");
         Move non_capture = moveParse ("e4 e8");
 
-        CHECK( moveEquals (capture, moveParse ("a6xb7", Color::White)) );
-        CHECK( moveEquals (non_capture, moveParse ("e4 e8", Color::White)) );
+        CHECK(( capture == moveParse ("a6xb7", Color::White)) );
+        CHECK(( non_capture == moveParse ("e4 e8", Color::White)) );
     }
 
     SUBCASE( "color matters in moveParse" )
     {
         Move castle = moveParse ("o-o", Color::Black);
-        CHECK( coordRow (castle.getSrc()) == 0 );
-        CHECK( coordRow (castle.getDst()) == 0 );
-        CHECK( moveEquals (castle, moveParse ("o-o", Color::Black)) );
+        CHECK(( coordRow (castle.getSrc()) == 0 ));
+        CHECK(( coordRow (castle.getDst()) == 0 ));
+        CHECK(( castle == moveParse ("o-o", Color::Black) ));
     }
 
     SUBCASE( "moveParse throws an exception for castling moves" )

--- a/ui/console/play.cpp
+++ b/ui/console/play.cpp
@@ -541,7 +541,7 @@ namespace wisdom::ui::console
 
                 for (auto legal_move : moves)
                 {
-                    if (optional_move.has_value() && moveEquals (legal_move, *optional_move))
+                    if (optional_move.has_value() && legal_move == *optional_move)
                     {
                         result = PlayCommand::PlayMove { *optional_move };
                         break;


### PR DESCRIPTION
`No_En_Passant_Coord` is the `First_Coord` (zero), but is just a special case.

It's better to use `optional<Coord>` to differentiate when we have a en passant state and not - so it's less easy to mix those states up.

Also, add a `clearEnPassantTargets()` function for the case when we need to clear the state explicitly.