### PR TITLE
Do out of line destructors for some classes

### DIFF
--- a/src/wisdom-chess/engine/game_status.cpp
+++ b/src/wisdom-chess/engine/game_status.cpp
@@ -1,5 +1,8 @@
 #include "wisdom-chess/engine/game_status.hpp"
 
+// Put destructor here to put vtable in this translation unit:
+wisdom::GameStatusUpdate::~GameStatusUpdate() = default;
+
 void wisdom::GameStatusUpdate::update (GameStatus status)
 {
     switch (status)

--- a/src/wisdom-chess/engine/game_status.hpp
+++ b/src/wisdom-chess/engine/game_status.hpp
@@ -30,7 +30,9 @@ namespace wisdom
     {
     public:
         GameStatusUpdate() = default;
-        virtual ~GameStatusUpdate() = default;
+
+        // Put virtual destructor in the .cpp file to put vtable there:
+        virtual ~GameStatusUpdate();
 
         // Run after a status update.
         void update (GameStatus status);

--- a/src/wisdom-chess/engine/logger.cpp
+++ b/src/wisdom-chess/engine/logger.cpp
@@ -4,6 +4,9 @@
 
 namespace wisdom
 {
+    // Put destructor here to put vtable in this translation unit:
+    Logger::~Logger() = default;
+
     class NullLogger : public Logger
     {
     public:

--- a/src/wisdom-chess/engine/logger.hpp
+++ b/src/wisdom-chess/engine/logger.hpp
@@ -13,7 +13,8 @@ namespace wisdom
             LogLevel_Debug = 1,
         };
 
-        virtual ~Logger() = default;
+        // Put virtual destructor in the .cpp file to put vtable there:
+        virtual ~Logger();
 
         virtual void debug (const string& output) const = 0;
         virtual void info (const string& output) const = 0;

--- a/src/wisdom-chess/engine/output_format.cpp
+++ b/src/wisdom-chess/engine/output_format.cpp
@@ -6,6 +6,9 @@
 
 namespace wisdom
 {
+    // Put destructor here to put vtable in this translation unit:
+    OutputFormat::~OutputFormat() = default;
+
     void 
     FenOutputFormat::save (
         const string& filename, 

--- a/src/wisdom-chess/engine/output_format.hpp
+++ b/src/wisdom-chess/engine/output_format.hpp
@@ -18,7 +18,8 @@ namespace wisdom
             Color turn
         ) = 0;
 
-        virtual ~OutputFormat() = default;
+        // virtual destructor to put vtable in .cpp file:
+        virtual ~OutputFormat();
     };
 
     class FenOutputFormat : public OutputFormat

--- a/src/wisdom-chess/ui/qml/main/chess_engine.cpp
+++ b/src/wisdom-chess/ui/qml/main/chess_engine.cpp
@@ -14,9 +14,20 @@ using std::shared_ptr;
 using wisdom::GameStatus;
 using wisdom::ProposedDrawType;
 
+void ChessEngine::ChessEngineLogger::debug (const std::string& line) const
+{
+    if (ChessEngine::Log_Level >= wisdom::Logger::LogLevel_Debug) 
+    {
+        qDebug() << line.c_str();
+    }
+}
+
 void ChessEngine::ChessEngineLogger::info (const std::string& line) const
 {
-    qDebug() << line.c_str();
+    if (ChessEngine::Log_Level >= wisdom::Logger::LogLevel_Info) 
+    {
+        qDebug() << line.c_str();
+    }
 }
 
 ChessEngine::ChessEngine (shared_ptr<ChessGame> game, int gameId, QObject* parent) :

--- a/src/wisdom-chess/ui/qml/main/chess_engine.hpp
+++ b/src/wisdom-chess/ui/qml/main/chess_engine.hpp
@@ -38,9 +38,7 @@ public:
 
     struct ChessEngineLogger : wisdom::Logger
     {
-        void debug (const std::string& string) const override
-        {
-        }
+        void debug (const std::string& string) const override;
 
         void info (const std::string& string) const override;
     };


### PR DESCRIPTION
According to Clang coding standards

https://llvm.org/docs/CodingStandards.html#provide-a-virtual-method-anchor-for-classes-in-headers

There can be a problem where a class gets emitted into each translation unit if it has virtual methods and not any out-of-line virtual methods.

To fix it, put the destructor out of line for those classes that don't have any.

Also, fixup logging for QML version.